### PR TITLE
fix(settings): isolate test environments via TempDir (closes #23)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
+ "tempfile",
  "tokio",
 ]
 
@@ -2272,6 +2273,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3509,6 +3516,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4645,6 +4665,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ aes-gcm = "0.10.3"
 base64 = "0.22"
 rand = "0.9"
 glib = "0.20"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -46,16 +46,19 @@ pub struct SettingsManager {
 }
 
 impl SettingsManager {
-    /// Create a new SettingsManager instance
+    /// Create a new SettingsManager instance using the default settings path
+    /// derived from the user's home directory.
     pub fn new() -> Result<Self, SettingsError> {
-        let settings_path = Self::get_settings_path();
-        
-        // Ensure directory exists
+        Self::with_path(Self::get_settings_path())
+    }
+
+    /// Create a new SettingsManager bound to a specific settings file path.
+    /// Used by `new()` and by tests that need an isolated settings file.
+    pub(crate) fn with_path(settings_path: PathBuf) -> Result<Self, SettingsError> {
         if let Some(parent) = settings_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        
-        // Load or create settings file
+
         let settings = if settings_path.exists() {
             Self::load_from_file(&settings_path)?
         } else {
@@ -63,19 +66,19 @@ impl SettingsManager {
             Self::save_to_file(&settings_path, &default_settings)?;
             default_settings
         };
-        
+
         Ok(Self {
             settings_path,
             settings,
         })
     }
-    
-    /// Get the settings file path
+
+    /// Get the default settings file path
     fn get_settings_path() -> PathBuf {
         let home = std::env::var("HOME")
             .or_else(|_| std::env::var("USERPROFILE"))
             .unwrap_or_else(|_| ".".to_string());
-        
+
         PathBuf::from(home)
             .join(".kakeibon")
             .join("KakeiBon.json")
@@ -172,160 +175,127 @@ impl SettingsManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
-    
-    fn setup_test_env() -> PathBuf {
-        let temp_dir = env::temp_dir().join(format!("kakeibon_test_{}", std::process::id()));
-        env::set_var("HOME", temp_dir.to_str().unwrap());
-        temp_dir
+    use tempfile::TempDir;
+
+    fn make_test_path() -> (PathBuf, TempDir) {
+        let temp_dir = TempDir::new().expect("create temp_dir");
+        let path = temp_dir.path().join(".kakeibon").join("KakeiBon.json");
+        (path, temp_dir)
     }
-    
-    fn cleanup_test_env(temp_dir: &PathBuf) {
-        let _ = fs::remove_dir_all(temp_dir);
-    }
-    
+
     #[test]
     fn test_settings_manager_creation() {
-        let temp_dir = setup_test_env();
-        
-        let manager = SettingsManager::new().unwrap();
+        let (path, _temp) = make_test_path();
+        let manager = SettingsManager::with_path(path).unwrap();
         assert!(manager.settings_path.exists());
-        
-        cleanup_test_env(&temp_dir);
     }
-    
+
     #[test]
     fn test_get_and_set_string() {
-        let temp_dir = setup_test_env();
-        
-        let mut manager = SettingsManager::new().unwrap();
-        
-        // Set a string value
+        let (path, _temp) = make_test_path();
+        let mut manager = SettingsManager::with_path(path).unwrap();
+
         manager.set("username", "test_user").unwrap();
-        
-        // Get the value back
         let username = manager.get_string("username").unwrap();
         assert_eq!(username, "test_user");
-        
-        cleanup_test_env(&temp_dir);
     }
-    
+
     #[test]
     fn test_get_and_set_int() {
-        let temp_dir = setup_test_env();
-        
-        let mut manager = SettingsManager::new().unwrap();
-        
+        let (path, _temp) = make_test_path();
+        let mut manager = SettingsManager::with_path(path).unwrap();
+
         manager.set("age", 25).unwrap();
         let age = manager.get_int("age").unwrap();
         assert_eq!(age, 25);
-        
-        cleanup_test_env(&temp_dir);
     }
-    
+
     #[test]
     fn test_get_and_set_bool() {
-        let temp_dir = setup_test_env();
-        
-        let mut manager = SettingsManager::new().unwrap();
-        
+        let (path, _temp) = make_test_path();
+        let mut manager = SettingsManager::with_path(path).unwrap();
+
         manager.set("enabled", true).unwrap();
         let enabled = manager.get_bool("enabled").unwrap();
         assert!(enabled);
-        
-        cleanup_test_env(&temp_dir);
     }
-    
+
     #[test]
     fn test_save_and_reload() {
-        let temp_dir = setup_test_env();
-        
+        let (path, _temp) = make_test_path();
+
         {
-            let mut manager = SettingsManager::new().unwrap();
+            let mut manager = SettingsManager::with_path(path.clone()).unwrap();
             manager.set("theme", "dark").unwrap();
             manager.save().unwrap();
         } // manager is dropped here
-        
-        // Create a new manager instance (simulates app restart)
-        let manager2 = SettingsManager::new().unwrap();
+
+        // Re-open the same settings file (simulates app restart)
+        let manager2 = SettingsManager::with_path(path).unwrap();
         let theme = manager2.get_string("theme").unwrap();
         assert_eq!(theme, "dark");
-        
-        cleanup_test_env(&temp_dir);
     }
-    
+
     #[test]
     fn test_remove_entry() {
-        let temp_dir = setup_test_env();
-        
-        let mut manager = SettingsManager::new().unwrap();
+        let (path, _temp) = make_test_path();
+        let mut manager = SettingsManager::with_path(path).unwrap();
         manager.set("temp_key", "temp_value").unwrap();
-        
+
         assert!(manager.contains_key("temp_key"));
-        
+
         manager.remove("temp_key");
         assert!(!manager.contains_key("temp_key"));
-        
-        cleanup_test_env(&temp_dir);
     }
-    
+
     #[test]
     fn test_entry_not_found() {
-        let temp_dir = setup_test_env();
-        
-        let manager = SettingsManager::new().unwrap();
+        let (path, _temp) = make_test_path();
+        let manager = SettingsManager::with_path(path).unwrap();
         let result = manager.get_string("nonexistent");
-        
+
         assert!(result.is_err());
         match result {
             Err(SettingsError::EntryNotFound(key)) => assert_eq!(key, "nonexistent"),
             _ => panic!("Expected EntryNotFound error"),
         }
-        
-        cleanup_test_env(&temp_dir);
     }
-    
+
     #[test]
     fn test_complex_type() {
-        let temp_dir = setup_test_env();
-        
         #[derive(Serialize, Deserialize, PartialEq, Debug)]
         struct WindowSettings {
             width: i32,
             height: i32,
             maximized: bool,
         }
-        
-        let mut manager = SettingsManager::new().unwrap();
+
+        let (path, _temp) = make_test_path();
+        let mut manager = SettingsManager::with_path(path).unwrap();
         let window_settings = WindowSettings {
             width: 1920,
             height: 1080,
             maximized: false,
         };
-        
+
         manager.set("window", &window_settings).unwrap();
         let loaded: WindowSettings = manager.get_as("window").unwrap();
-        
+
         assert_eq!(loaded, window_settings);
-        
-        cleanup_test_env(&temp_dir);
     }
-    
+
     #[test]
     fn test_keys_list() {
-        let temp_dir = setup_test_env();
-        
-        let mut manager = SettingsManager::new().unwrap();
+        let (path, _temp) = make_test_path();
+        let mut manager = SettingsManager::with_path(path).unwrap();
         manager.set("key1", "value1").unwrap();
         manager.set("key2", "value2").unwrap();
         manager.set("key3", "value3").unwrap();
-        
+
         let keys = manager.keys();
         assert_eq!(keys.len(), 3);
         assert!(keys.contains(&"key1".to_string()));
         assert!(keys.contains(&"key2".to_string()));
         assert!(keys.contains(&"key3".to_string()));
-        
-        cleanup_test_env(&temp_dir);
     }
 }


### PR DESCRIPTION
## Summary
Closes #23 — the long-standing flaky test `settings::tests::test_save_and_reload`.

## Root cause
`setup_test_env()` was using `env::set_var("HOME", ...)`, which is process-wide. The temp directory path was derived from `process::id()`, so every test in the process shared the same path. When two tests ran in parallel, the cleanup of one would `fs::remove_dir_all()` the shared directory underneath the other, and `test_save_and_reload`'s second `SettingsManager::new()` would create a fresh empty file — losing the `theme` key it had just saved.

## Fix
| Change | File |
|---|---|
| Add `tempfile = "3"` to `[dev-dependencies]` | `Cargo.toml` |
| Add `SettingsManager::with_path()` (pub(crate)) — new() now delegates to it | `src/settings.rs` |
| Replace `setup_test_env`/`cleanup_test_env` with a `make_test_path() -> (PathBuf, TempDir)` helper. Each test owns its own `TempDir` (auto-cleaned on Drop). No more `env::set_var` | `src/settings.rs` |

## Verification
```
$ for i in 1..5; cargo test --release
test result: ok. 266 passed; 0 failed; 0 ignored ...   (×5)
```

Previously this would fail roughly 1 in 5 release runs.

## Notes
- `with_path()` is `pub(crate)` — production callers still go through `new()`
- No production behavior change
- v2.0.1 milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)