### PR TITLE
fix(i18n): refresh Font Size submenu on language change (closes #25)

### DIFF
--- a/res/js/menu.js
+++ b/res/js/menu.js
@@ -558,10 +558,13 @@ async function handleLanguageChange(langCode) {
     try {
         console.log('Changing language to:', langCode);
         await i18n.setLanguage(langCode);
-        
-        // Reload language menu items to update display names and selection
+
+        // Reload menus whose items are generated dynamically.
+        // i18n.updateUI() only refreshes elements with data-i18n attributes,
+        // so menus built via textContent (Language, Font Size) need an explicit redraw.
         await setupLanguageMenu();
-        
+        await setupFontSizeMenu();
+
         console.log('Language changed successfully');
     } catch (error) {
         console.error('Failed to change language:', error);


### PR DESCRIPTION
## Summary
Closes #25 — Font Size submenu items remained in Japanese after switching language to English.

## Root cause
`handleLanguageChange()` (in `res/js/menu.js`) only redraws the **Language** menu after `i18n.setLanguage()`:

\`\`\`js
await i18n.setLanguage(langCode);
await setupLanguageMenu();   // <- only Language menu redrawn
\`\`\`

`i18n.updateUI()` (called inside `setLanguage()`) refreshes elements with the `data-i18n` attribute, but the Font Size submenu items are built dynamically via `item.textContent = i18n.t(size.key)` in `setupFontSizeMenu()` — no `data-i18n` attribute, so `updateUI()` never touches them. The result: the Font Size submenu sticks with whichever language was active when the page first loaded.

## Fix
One-line addition: call `setupFontSizeMenu()` immediately after `setupLanguageMenu()`. Both functions are already imported and idempotent.

\`\`\`js
await setupLanguageMenu();
await setupFontSizeMenu();   // <- new
\`\`\`

Comment added explaining *why* an explicit redraw is needed (so future contributors don't undo it).

## Verification
Backend tests (266) pass; no backend code touched. Frontend test suite has no `menu.js` coverage, so manual verification needed:

1. Launch app
2. Switch language to English (Language → English)
3. Open Font Size menu
4. **Expected**: Items show as Small / Medium / Large / Custom (was: 小 / 中 / 大 / カスタム)
5. Switch back to Japanese, verify items revert correctly

Please **restart the app** and verify before merging.

## Notes
- Same bug pattern likely exists for other dynamically-generated menus → tracked in #26 (Language menu unification)
- v2.0.1 milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)