### PR TITLE
fix(i18n): unify Language menu to native-script display (closes #26)

### DIFF
--- a/res/js/aggregation.js
+++ b/res/js/aggregation.js
@@ -299,18 +299,21 @@ function closeAllDropdowns() {
 
 async function setupLanguageMenu() {
     try {
-        const languages = await invoke('get_language_names');
+        // get_language_names returns Vec<(String, String)>, so destructure each
+        // tuple directly with `for ... of`. Object.entries() on this array would
+        // produce ["0", ["en", "English"]] pairs and break the rendering.
+        const languageNames = await invoke('get_language_names');
         const languageMenu = document.querySelector('.language-dropdown');
         if (!languageMenu) return;
 
         languageMenu.innerHTML = '';
 
-        for (const [code, name] of Object.entries(languages)) {
+        for (const [langCode, langName] of languageNames) {
             const item = document.createElement('a');
             item.href = '#';
             item.className = 'dropdown-item';
-            item.dataset.lang = code;
-            item.textContent = name;
+            item.dataset.lang = langCode;
+            item.textContent = langName;
             languageMenu.appendChild(item);
         }
 

--- a/res/js/category-management.js
+++ b/res/js/category-management.js
@@ -273,33 +273,35 @@ function setupLanguageMenuHandlers() {
 
 async function setupLanguageMenu() {
     try {
-        const languages = await invoke('get_available_languages');
+        // Fetch language names from backend. Each entry is shown in its own
+        // native script (English / 日本語 / ...) regardless of the current UI
+        // language, so users can always recognize the language they want.
+        const languageNames = await invoke('get_language_names');
         const currentLang = i18n.currentLanguage;
-        const languageNames = await invoke('get_language_names', { languages });
-        
+
         const languageDropdown = document.getElementById('language-dropdown');
         if (!languageDropdown) {
             return;
         }
-        
+
         languageDropdown.innerHTML = '';
-        
-        for (const lang of languages) {
+
+        for (const [langCode, langName] of languageNames) {
             const item = document.createElement('div');
             item.className = 'dropdown-item';
-            item.textContent = languageNames[lang] || lang;
-            item.dataset.langCode = lang;
-            
-            if (lang === currentLang) {
+            item.textContent = langName;
+            item.dataset.langCode = langCode;
+
+            if (langCode === currentLang) {
                 item.classList.add('active');
             }
-            
+
             item.addEventListener('click', async function(e) {
                 e.stopPropagation();
-                await handleLanguageChange(lang);
+                await handleLanguageChange(langCode);
                 languageDropdown.classList.remove('show');
             });
-            
+
             languageDropdown.appendChild(item);
         }
     } catch (error) {

--- a/res/js/dashboard.js
+++ b/res/js/dashboard.js
@@ -767,35 +767,30 @@ async function setupLanguageMenu() {
     if (!languageDropdown) return;
 
     try {
-        // Fixed language labels (not localized, so users can always understand)
-        const languages = [
-            { code: 'en', label: 'English' },
-            { code: 'ja', label: '日本語' }
-        ];
-
-        // Get current language
+        // Fetch language names from backend. Each entry is shown in its own
+        // native script (English / 日本語 / ...) regardless of the current UI
+        // language, so users can always recognize the language they want.
+        const languageNames = await invoke('get_language_names');
         const currentLang = i18n.getCurrentLanguage();
 
-        // Clear existing items
         languageDropdown.innerHTML = '';
 
-        // Add language items with individual click handlers
-        for (const lang of languages) {
+        for (const [langCode, langName] of languageNames) {
             const item = document.createElement('div');
             item.className = 'dropdown-item';
-            item.textContent = lang.label;
-            item.dataset.langCode = lang.code;
+            item.textContent = langName;
+            item.dataset.langCode = langCode;
 
             // Mark current language with active class
-            if (lang.code === currentLang) {
+            if (langCode === currentLang) {
                 item.classList.add('active');
             }
 
             // Add click handler for this language item
             item.addEventListener('click', async function(e) {
                 e.stopPropagation();
-                console.log('Language selected:', lang.code);
-                await changeLanguage(lang.code);
+                console.log('Language selected:', langCode);
+                await changeLanguage(langCode);
                 languageDropdown.classList.remove('show');
             });
 

--- a/res/js/menu.js
+++ b/res/js/menu.js
@@ -508,41 +508,34 @@ function setupLanguageMenuHandlers() {
 
 async function setupLanguageMenu() {
     try {
-        // Fixed language labels (not localized, so users can always understand)
-        const languages = [
-            { code: 'en', label: 'English' },
-            { code: 'ja', label: '日本語' }
-        ];
-
-        // Get current language
+        // Fetch language names from backend. Each entry is shown in its own
+        // native script (English / 日本語 / ...) regardless of the current UI
+        // language, so users can always recognize the language they want.
+        const languageNames = await invoke('get_language_names');
         const currentLang = i18n.getCurrentLanguage();
 
-        // Get dropdown container
         const languageDropdown = document.getElementById('language-dropdown');
-
         if (!languageDropdown) {
             console.error('Language dropdown not found');
             return;
         }
 
-        // Clear existing items only (not event listeners on parent)
         languageDropdown.innerHTML = '';
 
-        // Add language items with fixed labels
-        for (const lang of languages) {
+        for (const [langCode, langName] of languageNames) {
             const item = document.createElement('div');
             item.className = 'dropdown-item';
-            item.textContent = lang.label;
-            item.dataset.langCode = lang.code;
+            item.textContent = langName;
+            item.dataset.langCode = langCode;
 
             // Mark current language with active class (shows filled circle)
-            if (lang.code === currentLang) {
+            if (langCode === currentLang) {
                 item.classList.add('active');
             }
 
             item.addEventListener('click', async function(e) {
                 e.stopPropagation();
-                await handleLanguageChange(lang.code);
+                await handleLanguageChange(langCode);
                 languageDropdown.classList.remove('show');
             });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -705,26 +705,25 @@ async fn get_language_names(
     state: tauri::State<'_, AppState>
 ) -> Result<Vec<(String, String)>, String> {
     let i18n = state.i18n.lock().await;
-    let settings = state.settings.lock().await;
-    
-    let current_lang = settings.get_string("language")
-        .unwrap_or_else(|_| LANG_DEFAULT.to_string());
-    
+
     let lang_codes = i18n.get_available_languages()
         .await
         .map_err(|e| format!("Failed to get available languages: {}", e))?;
-    
+
+    // Each language is shown in its OWN locale (native name), so the menu
+    // reads the same regardless of the currently-selected UI language.
+    // Same convention as GitHub's language switcher and Wikipedia's interlanguage links.
     let mut language_names = Vec::new();
     for lang_code in lang_codes {
         let key = format!("lang.name.{}", lang_code);
-        if let Ok(name) = i18n.get(&key, &current_lang).await {
+        if let Ok(name) = i18n.get(&key, &lang_code).await {
             language_names.push((lang_code, name));
         }
     }
-    
+
     // Sort by language code to maintain consistent order
     language_names.sort_by(|a, b| a.0.cmp(&b.0));
-    
+
     Ok(language_names)
 }
 


### PR DESCRIPTION
## Summary
Closes #26 — Language menu items previously displayed in **3 different patterns** depending on which screen you were on. Unified to native-script display (`English` / `日本語`) across all 9 screens.

## Patterns observed (before)

| Pattern | Display (EN mode) | Files | Cause |
|---|---|---|---|
| **A** | `English` / `日本語` | `menu.js`, `dashboard.js` | Intentional hard-code (comment: "Fixed labels — users can always understand") |
| **B** | `English` / `Japanese` | `account/shop/product/user/manufacturer-management.js` | Backend returned localized labels; correctly rendered via tuple destructuring |
| **C** | `en` / `ja` | `category-management.js`, `aggregation.js` | **Bugs** (see below) |

### Bugs in Pattern C
- `category-management.js`: `languageNames[lang] \|\| lang` — but `get_language_names` returns `Vec<(String,String)>`, not an object. Object access yields `undefined`, falling back to `lang` itself
- `aggregation.js`: `Object.entries(languages)` on the tuple array — would produce `["0", ["en","English"]]` pairs

## Unification approach (Plan C from discussion)

**Backend** (`src/lib.rs`):
- `get_language_names()` now reads each `lang.name.{code}` resource **in its own locale** rather than the user's current locale
- Returns `[("en","English"), ("ja","日本語")]` regardless of UI language
- Same convention as GitHub's language switcher and Wikipedia's interlanguage links
- Settings lock removed (no longer needs current_lang)

**Frontend**:
| File | Change |
|---|---|
| `menu.js` | Drop hard-coded labels, call `get_language_names` |
| `dashboard.js` | Drop hard-coded labels, call `get_language_names` |
| `category-management.js` | Fix Vec-as-object bug via tuple destructuring |
| `aggregation.js` | Drop `Object.entries`; iterate tuple array directly |
| `account/shop/product/user/manufacturer-management.js` | **Untouched** — existing tuple-destructuring code picks up unified labels automatically |

## Why native-script display?
- Each language is recognizable regardless of current UI (Japanese user sees `English` and knows what it means; English user sees `日本語` and recognizes the script)
- Adding a new language requires only one i18n resource row (`lang.name.fr`, `'Français'`)
- Matches industry-standard convention (GitHub, Wikipedia)
- Eliminates the need for hard-coded labels (which got out of sync across screens — the root cause of this issue)

## Verification
- `cargo test --release` → 266/266 pass (no regression)
- Frontend manual verification needed:
  1. Restart app
  2. Open Language menu on **every** screen (dashboard, all *-management screens, aggregation views)
  3. **Expected**: every screen shows `English` and `日本語` (in that alphabetical order by code)
  4. Switch language; verify labels stay the same (only menu position/active state changes)

## Notes
- The 9-file duplication (each screen reimplements `setupLanguageMenu` independently) is the underlying technical debt that allowed these patterns to drift in the first place. **Consolidating into a shared `language-menu.js` module is recommended as a separate refactor** — out of scope for this fix but worth tracking
- v2.0.1 milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)