### PR TITLE
fix(transaction-detail): reset modal scroll on every open (#35)

### DIFF
--- a/res/js/transaction-detail-management.js
+++ b/res/js/transaction-detail-management.js
@@ -578,6 +578,13 @@ async function openDetailModal(detail = null) {
     
     modal.classList.remove('hidden');
 
+    // Reset modal content scroll so the form header is visible on every open.
+    // .modal-content has `overflow-y: auto`, and `.hidden` only toggles
+    // display:none — the inner scrollTop survives close/re-open, which made
+    // the 2nd+ open inherit the previous scroll position.
+    const modalContent = modal.querySelector('.modal-content');
+    if (modalContent) modalContent.scrollTop = 0;
+
     // Focus on item name input after modal opens (preventScroll to avoid modal shifting)
     setTimeout(() => document.getElementById('item-name')?.focus({ preventScroll: true }), 0);
 }


### PR DESCRIPTION
## Summary

Closes #35.

The transaction detail modal inherited its scroll position from the previously-open instance because `.modal.hidden` only toggles `display:none` — the DOM node stays mounted and `.modal-content` keeps its `scrollTop`. The 2nd+ open landed in the middle of the form with the header clipped.

Reset `modal-content.scrollTop = 0` in `openDetailModal` right after revealing the modal.

Net diff: +7 lines (2 lines of logic, 5 lines of comment explaining the cause).

## Test plan

- [x] Detail modal opens at the top on the 2nd, 3rd, … open (manually verified)
- [ ] No regression in 1st-open behaviour
- [ ] No regression in edit-mode pre-fill

🤖 Generated with [Claude Code](https://claude.com/claude-code)