### PR TITLE
feat(validation): foundation for unified bounded-field validation (#37 Phase 1)

### DIFF
--- a/res/js/validation-display.js
+++ b/res/js/validation-display.js
@@ -1,0 +1,78 @@
+/**
+ * Shared validation-error display helper.
+ *
+ * Renders a single inline error message immediately after the input
+ * element. Designed to be the one place that decides:
+ *   - where the message lives in the DOM (next sibling of the input)
+ *   - what it looks like (red, 12px, left-aligned, no layout shift)
+ *   - the placeholder substitution path (delegated to i18n.t)
+ *
+ * Phase 1 foundation for issue #37 — unused until services and HTML
+ * are wired up in Phase 2.
+ */
+
+import i18n from './i18n.js';
+
+const ERROR_CLASS = 'validation-error';
+const ERROR_STYLE = 'color:#c0392b;font-size:12px;margin-top:4px;line-height:1.3;';
+
+/**
+ * Show or update the inline error message for `inputEl`.
+ *
+ * @param {HTMLElement} inputEl - <input> or <textarea> element
+ * @param {string} message - already-translated, ready-to-display text
+ */
+export function showValidationError(inputEl, message) {
+    if (!inputEl) return;
+    let errorEl = findErrorElement(inputEl);
+    if (!errorEl) {
+        errorEl = document.createElement('div');
+        errorEl.className = ERROR_CLASS;
+        errorEl.style.cssText = ERROR_STYLE;
+        // Insert right after the input so the message tracks the field
+        // even when fields are inside grid/flex form rows.
+        inputEl.insertAdjacentElement('afterend', errorEl);
+    }
+    errorEl.textContent = message;
+}
+
+/**
+ * Remove the inline error message for `inputEl` (no-op if none exists).
+ *
+ * @param {HTMLElement} inputEl
+ */
+export function clearValidationError(inputEl) {
+    if (!inputEl) return;
+    const errorEl = findErrorElement(inputEl);
+    if (errorEl) errorEl.remove();
+}
+
+/**
+ * Convenience wrapper for the most common case: a max-length violation.
+ * Looks up the shared `validation.max_length` i18n message and substitutes
+ * the field label, max, and actual character count.
+ *
+ * @param {HTMLElement} inputEl
+ * @param {string} fieldLabel - localized name of the field (e.g. i18n.t('common.shop'))
+ * @param {number} max - the limit in characters
+ * @param {number} [actual] - current character count; defaults to inputEl.value length
+ */
+export function showMaxLengthError(inputEl, fieldLabel, max, actual) {
+    if (!inputEl) return;
+    const count = actual !== undefined
+        ? actual
+        : [...(inputEl.value || '')].length; // codepoint-aware count
+    const message = i18n.t('validation.max_length', {
+        field: fieldLabel,
+        max: max,
+        actual: count,
+    });
+    showValidationError(inputEl, message);
+}
+
+function findErrorElement(inputEl) {
+    const next = inputEl.nextElementSibling;
+    return next && next.classList && next.classList.contains(ERROR_CLASS)
+        ? next
+        : null;
+}

--- a/res/sql/dbaccess.sql
+++ b/res/sql/dbaccess.sql
@@ -1676,3 +1676,8 @@ INSERT OR IGNORE INTO I18N_RESOURCES (RESOURCE_ID, RESOURCE_KEY, LANG_CODE, RESO
 INSERT OR IGNORE INTO I18N_RESOURCES (RESOURCE_ID, RESOURCE_KEY, LANG_CODE, RESOURCE_VALUE, CATEGORY, DESCRIPTION, ENTRY_DT) VALUES (2289, 'recurring_rule.err_nth_weekday_invalid', 'en', 'Week and weekday must be selected.', 'recurring_rule', 'Validation error: NthWeekday inputs incomplete', datetime('now'));
 INSERT OR IGNORE INTO I18N_RESOURCES (RESOURCE_ID, RESOURCE_KEY, LANG_CODE, RESOURCE_VALUE, CATEGORY, DESCRIPTION, ENTRY_DT) VALUES (2290, 'recurring_rule.err_nth_weekday_invalid', 'ja', '第何週と曜日を選択してください。', 'recurring_rule', '検証エラー:第N週曜日入力不足', datetime('now'));
 
+-- Shared bounded-field validation message (issue #37 Phase 1 foundation).
+-- Placeholders: {field}, {max}, {actual}. Consumers replace before display.
+INSERT OR IGNORE INTO I18N_RESOURCES (RESOURCE_ID, RESOURCE_KEY, LANG_CODE, RESOURCE_VALUE, CATEGORY, DESCRIPTION, ENTRY_DT) VALUES (2291, 'validation.max_length', 'en', '{field} must be {max} characters or fewer (currently {actual}).', 'validation', 'Generic message for any text field exceeding its max length', datetime('now'));
+INSERT OR IGNORE INTO I18N_RESOURCES (RESOURCE_ID, RESOURCE_KEY, LANG_CODE, RESOURCE_VALUE, CATEGORY, DESCRIPTION, ENTRY_DT) VALUES (2292, 'validation.max_length', 'ja', '{field}は{max}文字以内で入力してください（現在{actual}文字）。', 'validation', '文字数上限超過時の汎用メッセージ', datetime('now'));
+

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -48,3 +48,18 @@ pub const MONTH_DAY_RULE_TYPE_DAY: &str = "DAY";
 pub const MONTH_DAY_RULE_TYPE_DAY_OR_END: &str = "DAY_OR_END";
 pub const MONTH_DAY_RULE_TYPE_END: &str = "END";
 pub const MONTH_DAY_RULE_TYPE_NTH_WEEKDAY: &str = "NTH_WEEKDAY";
+
+// Bounded-field length limits (in characters, not bytes).
+// Paired with `validation.max_length` i18n key for the user-facing message.
+// Existing `len() > N` byte-checks in `services/transaction.rs` will be
+// migrated to `chars().count() > N` in Phase 2 of issue #37.
+#[allow(dead_code)]
+pub const MAX_NAME_LEN: usize = 128;          // USERS.NAME, CATEGORY*_NAME, ACCOUNTS.ACCOUNT_NAME, SHOPS/MANUFACTURERS/PRODUCTS names
+#[allow(dead_code)]
+pub const MAX_I18N_NAME_LEN: usize = 256;     // CATEGORY*_I18N.*_NAME_I18N
+#[allow(dead_code)]
+pub const MAX_ITEM_NAME_LEN: usize = 200;     // TRANSACTIONS_DETAIL.ITEM_NAME, RECURRING_RULE_DETAILS.ITEM_NAME
+#[allow(dead_code)]
+pub const MAX_RULE_NAME_LEN: usize = 200;     // RECURRING_RULES.RULE_NAME
+#[allow(dead_code)]
+pub const MAX_MEMO_LEN: usize = 1000;         // MEMOS.MEMO_TEXT (used by transactions and recurring rules)


### PR DESCRIPTION
## Summary

Independent, **no-op groundwork** for the validation cleanup tracked in #37. This PR alone changes no runtime behaviour — the new constants, i18n key, and frontend helper have no callers yet. They become live in Phase 2 when services and HTML forms are wired up.

Goal of landing this separately: shrink the diff and review surface of the Phase 2 PRs, and let the foundation stabilize while the per-service rollout is split.

## Three additions

1. **`src/consts.rs`** — length limits in **characters** (not bytes), each marked `#[allow(dead_code)]` until consumers land. Values match the existing limits implied by `services/transaction.rs` and `recurring-rule.html`.
   - `MAX_NAME_LEN = 128`
   - `MAX_I18N_NAME_LEN = 256`
   - `MAX_ITEM_NAME_LEN = 200`
   - `MAX_RULE_NAME_LEN = 200`
   - `MAX_MEMO_LEN = 1000`

2. **`res/sql/dbaccess.sql`** — `validation.max_length` i18n key (RESOURCE_ID 2291/2292, JP/EN) with `{field}`, `{max}`, `{actual}` placeholders. Generic enough to be reused across every bounded text field.

3. **`res/js/validation-display.js`** — inline error renderer (`showValidationError` / `clearValidationError` / `showMaxLengthError`). Counts characters codepoint-aware so JP input agrees with the server-side check Phase 2 will introduce.

## Why deliberately not in this PR

- The `len()` → `chars().count()` migration in `services/transaction.rs` changes runtime behaviour (bytes → characters semantics) and is held for Phase 2.
- Per-service handler wiring (account / shop / manufacturer / etc.) and per-HTML `maxlength` rollout are split into Phase 2 PRs.

## Verification

- [x] `cargo build` succeeds with no new warnings (`#[allow(dead_code)]` suppresses unused-const warnings).
- [x] Existing tests untouched.
- [x] No behaviour change: no consumer references the new symbols yet.

Refs #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)