### PR TITLE
improve(login): autofocus username field on every login screen entry (#41)

### DIFF
--- a/res/js/menu.js
+++ b/res/js/menu.js
@@ -466,6 +466,7 @@ async function checkSetupNeeded() {
             adminSetup.classList.add('hidden');
             loginForm.classList.remove('hidden');
             appContent.classList.add('hidden');
+            document.getElementById('username')?.focus();
         }
     } catch (error) {
         console.error('Failed to check setup status:', error);
@@ -616,6 +617,7 @@ async function handleAdminSetup(e) {
         setTimeout(() => {
             document.getElementById('admin-setup').classList.add('hidden');
             document.getElementById('login-form').classList.remove('hidden');
+            document.getElementById('username')?.focus();
         }, 2000);
         
     } catch (error) {
@@ -755,6 +757,7 @@ async function handleLogout() {
         document.getElementById('login-message').textContent = '';
         loginForm.classList.remove('hidden');
         appContent.classList.add('hidden');
+        document.getElementById('username').focus();
     } else {
         // Management page - redirect to index
         window.location.href = HTML_FILES.INDEX;


### PR DESCRIPTION
## Summary

Closes #41.

The login form on `index.html` does not receive focus on its own. Every time the user reaches the login screen they have to Tab or click before typing. Small papercut.

Call `.focus()` on the username input at every code path that reveals the login form (`res/js/menu.js`):

1. `checkSetupNeeded()` — initial load when admin is already set up (the common path).
2. `handleAdminSetup()` — after admin registration succeeds and the login form fades in.
3. `handleLogout()` — when returning to the login form on the index page.

Three single-line additions, no new symbols, no behaviour change elsewhere.

## Test plan

- [x] Launch app → cursor blinks in username field
- [x] Logout from a logged-in session → cursor returns to username field
- [ ] First-time admin setup → after the 2-second success fade, username field is focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)