### PR TITLE
fix(transaction): count chars (not bytes) for bounded-field validation (#37 Phase 2-1)

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -51,15 +51,11 @@ pub const MONTH_DAY_RULE_TYPE_NTH_WEEKDAY: &str = "NTH_WEEKDAY";
 
 // Bounded-field length limits (in characters, not bytes).
 // Paired with `validation.max_length` i18n key for the user-facing message.
-// Existing `len() > N` byte-checks in `services/transaction.rs` will be
-// migrated to `chars().count() > N` in Phase 2 of issue #37.
 #[allow(dead_code)]
 pub const MAX_NAME_LEN: usize = 128;          // USERS.NAME, CATEGORY*_NAME, ACCOUNTS.ACCOUNT_NAME, SHOPS/MANUFACTURERS/PRODUCTS names
 #[allow(dead_code)]
 pub const MAX_I18N_NAME_LEN: usize = 256;     // CATEGORY*_I18N.*_NAME_I18N
-#[allow(dead_code)]
 pub const MAX_ITEM_NAME_LEN: usize = 200;     // TRANSACTIONS_DETAIL.ITEM_NAME, RECURRING_RULE_DETAILS.ITEM_NAME
 #[allow(dead_code)]
 pub const MAX_RULE_NAME_LEN: usize = 200;     // RECURRING_RULES.RULE_NAME
-#[allow(dead_code)]
 pub const MAX_MEMO_LEN: usize = 1000;         // MEMOS.MEMO_TEXT (used by transactions and recurring rules)

--- a/src/services/transaction.rs
+++ b/src/services/transaction.rs
@@ -438,9 +438,9 @@ impl TransactionService {
         // Save memo if provided
         let memo_id = if let Some(text) = &request.memo {
             if !text.trim().is_empty() {
-                if text.len() > 1000 {
+                if text.chars().count() > consts::MAX_MEMO_LEN {
                     return Err(TransactionError::ValidationError(
-                        "Memo must be 1000 characters or less".to_string(),
+                        format!("Memo must be {} characters or less", consts::MAX_MEMO_LEN),
                     ));
                 }
                 let result = sqlx::query(sql_queries::MEMO_INSERT)
@@ -519,9 +519,9 @@ impl TransactionService {
         // Save memo if provided
         let memo_id = if let Some(text) = memo_text {
             if !text.trim().is_empty() {
-                if text.len() > 1000 {
+                if text.chars().count() > consts::MAX_MEMO_LEN {
                     return Err(TransactionError::ValidationError(
-                        "Memo must be 1000 characters or less".to_string(),
+                        format!("Memo must be {} characters or less", consts::MAX_MEMO_LEN),
                     ));
                 }
                 let result = sqlx::query(sql_queries::MEMO_INSERT)
@@ -639,7 +639,7 @@ impl TransactionService {
                     "Description cannot be empty or whitespace only".to_string(),
                 ));
             }
-            if desc.len() > 500 {
+            if desc.chars().count() > 500 {
                 return Err(TransactionError::ValidationError(
                     "Description must be 500 characters or less".to_string(),
                 ));
@@ -653,9 +653,9 @@ impl TransactionService {
                     "Memo cannot be empty or whitespace only".to_string(),
                 ));
             }
-            if m.len() > 1000 {
+            if m.chars().count() > consts::MAX_MEMO_LEN {
                 return Err(TransactionError::ValidationError(
-                    "Memo must be 1000 characters or less".to_string(),
+                    format!("Memo must be {} characters or less", consts::MAX_MEMO_LEN),
                 ));
             }
         }
@@ -925,9 +925,9 @@ impl TransactionService {
         }
 
         // Validate memo length
-        if memo_text.len() > 1000 {
+        if memo_text.chars().count() > consts::MAX_MEMO_LEN {
             return Err(TransactionError::ValidationError(
-                "Memo must be 1000 characters or less".to_string(),
+                format!("Memo must be {} characters or less", consts::MAX_MEMO_LEN),
             ));
         }
 
@@ -969,9 +969,9 @@ impl TransactionService {
         }
 
         // Validate memo length
-        if memo_text.len() > 1000 {
+        if memo_text.chars().count() > consts::MAX_MEMO_LEN {
             return Err(TransactionError::ValidationError(
-                "Memo must be 1000 characters or less".to_string(),
+                format!("Memo must be {} characters or less", consts::MAX_MEMO_LEN),
             ));
         }
 
@@ -1178,9 +1178,9 @@ impl TransactionService {
             ));
         }
 
-        if request.item_name.len() > 200 {
+        if request.item_name.chars().count() > consts::MAX_ITEM_NAME_LEN {
             return Err(TransactionError::ValidationError(
-                "Item name must be 200 characters or less".to_string(),
+                format!("Item name must be {} characters or less", consts::MAX_ITEM_NAME_LEN),
             ));
         }
 
@@ -1208,9 +1208,9 @@ impl TransactionService {
         // Save memo if provided
         let memo_id = if let Some(text) = &request.memo {
             if !text.trim().is_empty() {
-                if text.len() > 1000 {
+                if text.chars().count() > consts::MAX_MEMO_LEN {
                     return Err(TransactionError::ValidationError(
-                        "Memo must be 1000 characters or less".to_string(),
+                        format!("Memo must be {} characters or less", consts::MAX_MEMO_LEN),
                     ));
                 }
                 let result = sqlx::query(sql_queries::MEMO_INSERT)
@@ -1259,9 +1259,9 @@ impl TransactionService {
             ));
         }
 
-        if request.item_name.len() > 200 {
+        if request.item_name.chars().count() > consts::MAX_ITEM_NAME_LEN {
             return Err(TransactionError::ValidationError(
-                "Item name must be 200 characters or less".to_string(),
+                format!("Item name must be {} characters or less", consts::MAX_ITEM_NAME_LEN),
             ));
         }
 
@@ -1300,9 +1300,9 @@ impl TransactionService {
         // Handle memo update
         let memo_id = if let Some(text) = &request.memo {
             if !text.trim().is_empty() {
-                if text.len() > 1000 {
+                if text.chars().count() > consts::MAX_MEMO_LEN {
                     return Err(TransactionError::ValidationError(
-                        "Memo must be 1000 characters or less".to_string(),
+                        format!("Memo must be {} characters or less", consts::MAX_MEMO_LEN),
                     ));
                 }
                 
@@ -3275,6 +3275,81 @@ mod tests {
             2, None, None, None, None, None, None, None, None, true, 1, 50
         ).await.unwrap();
         assert_eq!(result.total_count, 2);
+    }
+
+    // Issue #37 — bounded-field length checks must count characters, not bytes.
+    // Japanese characters are 3 bytes in UTF-8; the previous `.len()` check
+    // capped Japanese input at ~MAX/3 characters even though the message said
+    // "MAX characters or less".
+
+    #[tokio::test]
+    async fn test_item_name_accepts_max_chars_of_multibyte_input() {
+        let pool = setup_test_db().await;
+        let service = TransactionService::new(pool);
+        let transaction_id = create_test_header(&service).await;
+
+        // 200 Japanese characters = 600 bytes — would have been rejected by
+        // the old byte-based check, must pass the new character-based check.
+        let item_name: String = "あ".repeat(consts::MAX_ITEM_NAME_LEN);
+        let mut request = basic_detail_request();
+        request.item_name = item_name;
+
+        let result = service.add_transaction_detail(2, transaction_id, request).await;
+        assert!(result.is_ok(), "expected MAX_ITEM_NAME_LEN multibyte chars to be accepted: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn test_item_name_rejects_over_max_chars_of_multibyte_input() {
+        let pool = setup_test_db().await;
+        let service = TransactionService::new(pool);
+        let transaction_id = create_test_header(&service).await;
+
+        let item_name: String = "あ".repeat(consts::MAX_ITEM_NAME_LEN + 1);
+        let mut request = basic_detail_request();
+        request.item_name = item_name;
+
+        let err = service.add_transaction_detail(2, transaction_id, request).await.unwrap_err();
+        match err {
+            TransactionError::ValidationError(msg) => {
+                assert!(msg.contains(&consts::MAX_ITEM_NAME_LEN.to_string()),
+                    "error message should reference the limit: {}", msg);
+            }
+            other => panic!("expected ValidationError, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_memo_accepts_max_chars_of_multibyte_input() {
+        let pool = setup_test_db().await;
+        let service = TransactionService::new(pool);
+        let transaction_id = create_test_header(&service).await;
+
+        let memo: String = "あ".repeat(consts::MAX_MEMO_LEN);
+        let mut request = basic_detail_request();
+        request.memo = Some(memo);
+
+        let result = service.add_transaction_detail(2, transaction_id, request).await;
+        assert!(result.is_ok(), "expected MAX_MEMO_LEN multibyte chars to be accepted: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn test_memo_rejects_over_max_chars_of_multibyte_input() {
+        let pool = setup_test_db().await;
+        let service = TransactionService::new(pool);
+        let transaction_id = create_test_header(&service).await;
+
+        let memo: String = "あ".repeat(consts::MAX_MEMO_LEN + 1);
+        let mut request = basic_detail_request();
+        request.memo = Some(memo);
+
+        let err = service.add_transaction_detail(2, transaction_id, request).await.unwrap_err();
+        match err {
+            TransactionError::ValidationError(msg) => {
+                assert!(msg.contains(&consts::MAX_MEMO_LEN.to_string()),
+                    "error message should reference the limit: {}", msg);
+            }
+            other => panic!("expected ValidationError, got {:?}", other),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Migrates the 10 byte-based length checks in `services/transaction.rs`
from `text.len() > N` to `text.chars().count() > N`.

The previous checks counted UTF-8 bytes but reported the limit as
"characters" — Japanese input (3 bytes/char) was effectively capped at
~66 chars under a "200 characters" item-name limit and ~333 chars under
a "1000 characters" memo limit. Migration aligns the limit with what
the message claims.

## Why now

This is the bytes→chars migration step of issue #37 Phase 2 (the only
existing-behavior change in Phase 2). It is split into its own PR so
that the horizontal rollout PR (HTML `maxlength` + new service
validation) is purely additive against this baseline and cannot mask
this regression in review. PR 2 will follow.

## What changed

- `src/services/transaction.rs`: 10 sites migrated to `chars().count()`.
  Item-name and memo sites now use `consts::MAX_ITEM_NAME_LEN` and
  `consts::MAX_MEMO_LEN` (defined in #38) via `format!`. The legacy
  `add_transaction`/`update_transaction` description check (500, not in
  the issue inventory) is migrated to chars-based for consistency,
  retaining the literal since it is on a Tauri command path with no
  current frontend caller.
- `src/consts.rs`: `#[allow(dead_code)]` removed from
  `MAX_ITEM_NAME_LEN` and `MAX_MEMO_LEN` now that they have callers.
  `MAX_NAME_LEN` / `MAX_I18N_NAME_LEN` / `MAX_RULE_NAME_LEN` keep the
  attribute — they will be used in PR 2.
- 4 new multibyte boundary tests in the existing test module.

## Test plan

- [x] `cargo test --lib` — 315 pass, 0 fail (including 4 new
      multibyte tests in `services::transaction::tests`)
- [x] `cargo clippy --lib --tests` on touched files — no new warnings
      (pre-existing warnings on other lines unchanged)
- [ ] Manual: enter a 200-character Japanese item name in transaction
      detail and confirm it saves (would have been rejected previously)

## Out of scope (PR 2 of 2)

- Adding length checks to `account` / `shop` / `manufacturer` / `product`
  / `recurring` / `user_management` / `category` services
- Adding `maxlength` to all HTML inputs (currently only
  `recurring-rule.html` has them)
- Wiring `validation-display.js` for inline + toast UX
- Refining error message to use the shared `validation.max_length`
  i18n key with `{field}` / `{max}` / `{actual}` placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)