### PR TITLE
feat(shop): bounded-field validation + live char counter as Phase 2-2 template (#37)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ DB: ~/.kakeibon/KakeiBonDB.sqlite3
 ```bash
 cargo tauri dev          # Development
 cargo test               # Backend tests
-cd res && npm test       # Frontend tests
+cd res/tests && npm test # Frontend tests (Jest)
 ./scripts/check-release.sh  # Pre-release verification
 ```
 

--- a/res/js/consts.js
+++ b/res/js/consts.js
@@ -37,3 +37,11 @@ export const TAX_ROUND_UP = 2;
 // Tax inclusion type constants (must match src/consts.rs)
 export const TAX_INCLUDED = 0;  // 内税 - tax is included in prices
 export const TAX_EXCLUDED = 1;  // 外税 - tax is calculated separately
+
+// Bounded-field length limits in characters (must match src/consts.rs).
+// Used by HTML maxlength + JS submit-time validation.
+export const MAX_NAME_LEN = 128;        // shop/manufacturer/product/account/category/user names
+export const MAX_I18N_NAME_LEN = 256;   // category i18n names
+export const MAX_ITEM_NAME_LEN = 200;   // transaction detail item_name, recurring rule detail item_name
+export const MAX_RULE_NAME_LEN = 200;   // recurring rule name
+export const MAX_MEMO_LEN = 1000;       // memo fields (transactions, recurring rules, shops, etc.)

--- a/res/js/shop-management.js
+++ b/res/js/shop-management.js
@@ -6,7 +6,7 @@ import { Modal } from './modal.js';
 import { setupIndicators } from './indicators.js';
 import { getCurrentSessionUser, isSessionAuthenticated, getSessionSourceScreen, clearSessionSourceScreen } from './session.js';
 import { createMenuBar } from './menu.js';
-import { showValidationError, clearValidationError, showMaxLengthError } from './validation-display.js';
+import { showValidationError, clearValidationError, showMaxLengthError, attachCharCounter } from './validation-display.js';
 import { MAX_NAME_LEN, MAX_MEMO_LEN } from './consts.js';
 
 console.log('=== SHOP-MANAGEMENT.JS LOADED ===');
@@ -90,8 +90,10 @@ function initShopModal() {
             // Clear form and errors
             form.reset();
             clearErrors();
-            clearValidationError(document.getElementById('shop-name'));
-            clearValidationError(document.getElementById('shop-memo'));
+            const shopNameEl = document.getElementById('shop-name');
+            const shopMemoEl = document.getElementById('shop-memo');
+            clearValidationError(shopNameEl);
+            clearValidationError(shopMemoEl);
 
             if (mode === 'add') {
                 modalTitle.setAttribute('data-i18n', 'shop_mgmt.modal_title_add');
@@ -102,11 +104,16 @@ function initShopModal() {
                 modalTitle.textContent = i18n.t('shop_mgmt.modal_title_edit');
 
                 // Populate form
-                document.getElementById('shop-name').value = data.shop_name;
-                document.getElementById('shop-memo').value = data.memo || '';
+                shopNameEl.value = data.shop_name;
+                shopMemoEl.value = data.memo || '';
 
                 editingShopId = data.shop_id;
             }
+
+            // Refresh character counters after programmatic value changes
+            // (form.reset() / direct .value assignments do not fire 'input').
+            shopNameEl?.dispatchEvent(new Event('input'));
+            shopMemoEl?.dispatchEvent(new Event('input'));
         },
         onSave: async (formData) => {
             await saveShop();
@@ -151,6 +158,10 @@ function setupEventListeners() {
     const memoInput = document.getElementById('shop-memo');
     shopNameInput?.addEventListener('input', () => clearValidationError(shopNameInput));
     memoInput?.addEventListener('input', () => clearValidationError(memoInput));
+
+    // Live character counters (kept in sync with backend chars().count())
+    if (shopNameInput) attachCharCounter(shopNameInput, MAX_NAME_LEN);
+    if (memoInput) attachCharCounter(memoInput, MAX_MEMO_LEN);
 }
 
 function openModal(mode, data = null) {

--- a/res/js/shop-management.js
+++ b/res/js/shop-management.js
@@ -6,6 +6,8 @@ import { Modal } from './modal.js';
 import { setupIndicators } from './indicators.js';
 import { getCurrentSessionUser, isSessionAuthenticated, getSessionSourceScreen, clearSessionSourceScreen } from './session.js';
 import { createMenuBar } from './menu.js';
+import { showValidationError, clearValidationError, showMaxLengthError } from './validation-display.js';
+import { MAX_NAME_LEN, MAX_MEMO_LEN } from './consts.js';
 
 console.log('=== SHOP-MANAGEMENT.JS LOADED ===');
 
@@ -88,6 +90,8 @@ function initShopModal() {
             // Clear form and errors
             form.reset();
             clearErrors();
+            clearValidationError(document.getElementById('shop-name'));
+            clearValidationError(document.getElementById('shop-memo'));
 
             if (mode === 'add') {
                 modalTitle.setAttribute('data-i18n', 'shop_mgmt.modal_title_add');
@@ -141,6 +145,12 @@ function setupEventListeners() {
     document.getElementById('add-shop-btn').addEventListener('click', () => {
         openModal('add');
     });
+
+    // Live-clear validation errors as the user edits
+    const shopNameInput = document.getElementById('shop-name');
+    const memoInput = document.getElementById('shop-memo');
+    shopNameInput?.addEventListener('input', () => clearValidationError(shopNameInput));
+    memoInput?.addEventListener('input', () => clearValidationError(memoInput));
 }
 
 function openModal(mode, data = null) {
@@ -237,16 +247,30 @@ function renderShops() {
 }
 
 async function saveShop() {
-    const shopName = document.getElementById('shop-name').value.trim();
-    const memo = document.getElementById('shop-memo').value.trim();
+    const shopNameInput = document.getElementById('shop-name');
+    const memoInput = document.getElementById('shop-memo');
+    const shopName = shopNameInput.value.trim();
+    const memo = memoInput.value.trim();
 
     // Clear previous errors
     clearErrors();
+    clearValidationError(shopNameInput);
+    clearValidationError(memoInput);
 
-    // Validation
+    // Validation — empty name
     if (!shopName) {
-        document.getElementById('shop-name-error').textContent = i18n.t('shop_mgmt.empty_name');
+        showValidationError(shopNameInput, i18n.t('shop_mgmt.empty_name'));
         throw new Error('Validation error: empty shop name');
+    }
+
+    // Validation — max length (mirrors Rust defense in src/services/shop.rs)
+    if ([...shopName].length > MAX_NAME_LEN) {
+        showMaxLengthError(shopNameInput, i18n.t('shop_mgmt.shop_name'), MAX_NAME_LEN);
+        throw new Error('Validation error: shop name too long');
+    }
+    if (memo && [...memo].length > MAX_MEMO_LEN) {
+        showMaxLengthError(memoInput, i18n.t('shop_mgmt.memo'), MAX_MEMO_LEN);
+        throw new Error('Validation error: memo too long');
     }
 
     try {
@@ -282,20 +306,36 @@ async function saveShop() {
     } catch (error) {
         console.error('Failed to save shop:', error);
 
-        // Map backend error messages to i18n resources
+        // Map backend error messages to i18n resources / localized text
         const errorMessage = error.toString();
-        let displayMessage;
+        let nameMessage = null;
+        let memoMessage = null;
 
         if (errorMessage.includes('already exists')) {
-            displayMessage = i18n.t('shop_mgmt.duplicate_error');
+            nameMessage = i18n.t('shop_mgmt.duplicate_error');
+        } else if (errorMessage.includes('Shop name must be')) {
+            // Defense-line trip: frontend max-length check should have caught
+            // this, so use the same i18n message for parity.
+            nameMessage = i18n.t('validation.max_length', {
+                field: i18n.t('shop_mgmt.shop_name'),
+                max: MAX_NAME_LEN,
+                actual: [...shopName].length,
+            });
+        } else if (errorMessage.includes('Memo must be')) {
+            memoMessage = i18n.t('validation.max_length', {
+                field: i18n.t('shop_mgmt.memo'),
+                max: MAX_MEMO_LEN,
+                actual: [...memo].length,
+            });
         } else if (errorMessage.includes('cannot be empty')) {
-            displayMessage = i18n.t('shop_mgmt.empty_name');
+            nameMessage = i18n.t('shop_mgmt.empty_name');
         } else {
-            // Fallback to original error message
-            displayMessage = errorMessage;
+            // Fallback to original error message on the name field
+            nameMessage = errorMessage;
         }
 
-        document.getElementById('shop-name-error').textContent = displayMessage;
+        if (nameMessage) showValidationError(shopNameInput, nameMessage);
+        if (memoMessage) showValidationError(memoInput, memoMessage);
 
         // Re-throw error to prevent modal from closing
         throw error;

--- a/res/js/validation-display.js
+++ b/res/js/validation-display.js
@@ -15,6 +15,8 @@ import i18n from './i18n.js';
 
 const ERROR_CLASS = 'validation-error';
 const ERROR_STYLE = 'color:#c0392b;font-size:12px;margin-top:4px;line-height:1.3;';
+const COUNTER_CLASS = 'char-counter';
+const COUNTER_STYLE = 'color:#888;font-size:11px;margin-top:2px;text-align:right;line-height:1.3;';
 
 /**
  * Show or update the inline error message for `inputEl`.
@@ -70,9 +72,67 @@ export function showMaxLengthError(inputEl, fieldLabel, max, actual) {
     showValidationError(inputEl, message);
 }
 
+/**
+ * Attach a live character counter ("actual / max") to a bounded-length
+ * input/textarea. Updates on every `input` event. Counts Unicode code
+ * points via `[...str].length` so the displayed count matches the
+ * backend's `chars().count()` validation (surrogate pairs count as one).
+ *
+ * Idempotent: calling twice on the same element reuses the existing
+ * counter and replaces the listener.
+ *
+ * @param {HTMLElement} inputEl - <input> or <textarea> element
+ * @param {number} max - limit in characters (same value as backend bound)
+ * @returns {() => void} detach — removes the listener and counter element
+ */
+export function attachCharCounter(inputEl, max) {
+    if (!inputEl) return () => {};
+
+    let counterEl = findCounterElement(inputEl);
+    if (!counterEl) {
+        counterEl = document.createElement('div');
+        counterEl.className = COUNTER_CLASS;
+        counterEl.style.cssText = COUNTER_STYLE;
+        inputEl.insertAdjacentElement('afterend', counterEl);
+    }
+
+    // Replace any prior listener attached by an earlier call.
+    if (inputEl.__charCounterHandler) {
+        inputEl.removeEventListener('input', inputEl.__charCounterHandler);
+    }
+
+    const update = () => {
+        const count = [...(inputEl.value || '')].length;
+        counterEl.textContent = `${count} / ${max}`;
+    };
+    inputEl.__charCounterHandler = update;
+    inputEl.addEventListener('input', update);
+    update();
+
+    return () => {
+        inputEl.removeEventListener('input', update);
+        if (inputEl.__charCounterHandler === update) {
+            delete inputEl.__charCounterHandler;
+        }
+        counterEl.remove();
+    };
+}
+
 function findErrorElement(inputEl) {
-    const next = inputEl.nextElementSibling;
-    return next && next.classList && next.classList.contains(ERROR_CLASS)
-        ? next
-        : null;
+    return findSiblingByClass(inputEl, ERROR_CLASS);
+}
+
+function findCounterElement(inputEl) {
+    return findSiblingByClass(inputEl, COUNTER_CLASS);
+}
+
+function findSiblingByClass(inputEl, className) {
+    let sibling = inputEl.nextElementSibling;
+    while (sibling) {
+        if (sibling.classList && sibling.classList.contains(className)) {
+            return sibling;
+        }
+        sibling = sibling.nextElementSibling;
+    }
+    return null;
 }

--- a/res/shop-management.html
+++ b/res/shop-management.html
@@ -62,14 +62,14 @@
                     <div class="form-group">
                         <label for="shop-name" data-i18n="shop_mgmt.shop_name">Shop Name:</label>
                         <div class="input-wrapper">
-                            <input type="text" id="shop-name" name="shop-name" required />
+                            <input type="text" id="shop-name" name="shop-name" maxlength="128" required />
                         </div>
                     </div>
 
                     <div class="form-group">
                         <label for="shop-memo" data-i18n="shop_mgmt.memo">Memo:</label>
                         <div class="input-wrapper">
-                            <textarea id="shop-memo" name="shop-memo" rows="3"></textarea>
+                            <textarea id="shop-memo" name="shop-memo" rows="3" maxlength="1000"></textarea>
                         </div>
                     </div>
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -51,7 +51,6 @@ pub const MONTH_DAY_RULE_TYPE_NTH_WEEKDAY: &str = "NTH_WEEKDAY";
 
 // Bounded-field length limits (in characters, not bytes).
 // Paired with `validation.max_length` i18n key for the user-facing message.
-#[allow(dead_code)]
 pub const MAX_NAME_LEN: usize = 128;          // USERS.NAME, CATEGORY*_NAME, ACCOUNTS.ACCOUNT_NAME, SHOPS/MANUFACTURERS/PRODUCTS names
 #[allow(dead_code)]
 pub const MAX_I18N_NAME_LEN: usize = 256;     // CATEGORY*_I18N.*_NAME_I18N

--- a/src/services/shop.rs
+++ b/src/services/shop.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use sqlx::{SqlitePool, FromRow};
-use crate::sql_queries;
+use crate::{sql_queries, consts};
 
 #[derive(Debug, Serialize, Deserialize, Clone, FromRow)]
 #[sqlx(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -114,6 +114,16 @@ pub async fn add_shop(
     if request.shop_name.trim().is_empty() {
         return Err("Shop name cannot be empty".to_string());
     }
+    if request.shop_name.chars().count() > consts::MAX_NAME_LEN {
+        return Err(format!("Shop name must be {} characters or less", consts::MAX_NAME_LEN));
+    }
+
+    // Validate memo length
+    if let Some(memo) = &request.memo {
+        if memo.chars().count() > consts::MAX_MEMO_LEN {
+            return Err(format!("Memo must be {} characters or less", consts::MAX_MEMO_LEN));
+        }
+    }
 
     // Check for duplicate shop name
     if check_duplicate_for_add(pool, user_id, &request.shop_name).await? {
@@ -146,6 +156,16 @@ pub async fn update_shop(
     // Validate shop name
     if request.shop_name.trim().is_empty() {
         return Err("Shop name cannot be empty".to_string());
+    }
+    if request.shop_name.chars().count() > consts::MAX_NAME_LEN {
+        return Err(format!("Shop name must be {} characters or less", consts::MAX_NAME_LEN));
+    }
+
+    // Validate memo length
+    if let Some(memo) = &request.memo {
+        if memo.chars().count() > consts::MAX_MEMO_LEN {
+            return Err(format!("Memo must be {} characters or less", consts::MAX_MEMO_LEN));
+        }
     }
 
     // Check if shop exists
@@ -390,5 +410,102 @@ mod tests {
         // Verify memo was updated
         let shop = get_shop_by_id(&pool, 2, shop_id).await.unwrap().unwrap();
         assert_eq!(shop.memo, Some("新しいメモ".to_string()));
+    }
+
+    // Issue #37 Phase 2-2 — bounded-field length checks must count
+    // characters (not bytes). Japanese is 3 bytes per char in UTF-8.
+
+    #[tokio::test]
+    async fn test_add_shop_accepts_max_chars_of_multibyte_name() {
+        let pool = setup_test_db().await;
+
+        let request = AddShopRequest {
+            shop_name: "あ".repeat(consts::MAX_NAME_LEN),
+            memo: None,
+        };
+        let result = add_shop(&pool, 2, request).await;
+        assert!(result.is_ok(), "expected MAX_NAME_LEN multibyte chars to be accepted: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn test_add_shop_rejects_over_max_chars_of_multibyte_name() {
+        let pool = setup_test_db().await;
+
+        let request = AddShopRequest {
+            shop_name: "あ".repeat(consts::MAX_NAME_LEN + 1),
+            memo: None,
+        };
+        let err = add_shop(&pool, 2, request).await.unwrap_err();
+        assert!(err.contains(&consts::MAX_NAME_LEN.to_string()),
+            "error should reference the limit: {}", err);
+    }
+
+    #[tokio::test]
+    async fn test_add_shop_accepts_max_chars_of_multibyte_memo() {
+        let pool = setup_test_db().await;
+
+        let request = AddShopRequest {
+            shop_name: "店".to_string(),
+            memo: Some("メ".repeat(consts::MAX_MEMO_LEN)),
+        };
+        let result = add_shop(&pool, 2, request).await;
+        assert!(result.is_ok(), "expected MAX_MEMO_LEN multibyte chars to be accepted: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn test_add_shop_rejects_over_max_chars_of_multibyte_memo() {
+        let pool = setup_test_db().await;
+
+        let request = AddShopRequest {
+            shop_name: "店".to_string(),
+            memo: Some("メ".repeat(consts::MAX_MEMO_LEN + 1)),
+        };
+        let err = add_shop(&pool, 2, request).await.unwrap_err();
+        assert!(err.contains(&consts::MAX_MEMO_LEN.to_string()),
+            "error should reference the limit: {}", err);
+    }
+
+    #[tokio::test]
+    async fn test_update_shop_rejects_over_max_chars_of_multibyte_name() {
+        let pool = setup_test_db().await;
+
+        let add_request = AddShopRequest {
+            shop_name: "店".to_string(),
+            memo: None,
+        };
+        add_shop(&pool, 2, add_request).await.unwrap();
+        let shops = get_shops(&pool, 2).await.unwrap();
+        let shop_id = shops[0].shop_id;
+
+        let update_request = UpdateShopRequest {
+            shop_name: "あ".repeat(consts::MAX_NAME_LEN + 1),
+            memo: None,
+            display_order: 1,
+        };
+        let err = update_shop(&pool, 2, shop_id, update_request).await.unwrap_err();
+        assert!(err.contains(&consts::MAX_NAME_LEN.to_string()),
+            "error should reference the limit: {}", err);
+    }
+
+    #[tokio::test]
+    async fn test_update_shop_rejects_over_max_chars_of_multibyte_memo() {
+        let pool = setup_test_db().await;
+
+        let add_request = AddShopRequest {
+            shop_name: "店".to_string(),
+            memo: None,
+        };
+        add_shop(&pool, 2, add_request).await.unwrap();
+        let shops = get_shops(&pool, 2).await.unwrap();
+        let shop_id = shops[0].shop_id;
+
+        let update_request = UpdateShopRequest {
+            shop_name: "店".to_string(),
+            memo: Some("メ".repeat(consts::MAX_MEMO_LEN + 1)),
+            display_order: 1,
+        };
+        let err = update_shop(&pool, 2, shop_id, update_request).await.unwrap_err();
+        assert!(err.contains(&consts::MAX_MEMO_LEN.to_string()),
+            "error should reference the limit: {}", err);
     }
 }


### PR DESCRIPTION
## Summary

Wires the Phase 1 validation foundation (`consts`, `validation.max_length`
i18n key, `validation-display.js`) into the shop management screen as
the first end-to-end implementation of issue #37 Phase 2-2, and adds a
**live character counter** so users see the limit before they hit it.
This serves as the **template** the remaining services will follow.

## Pattern (decided 2026-05-16)

Three-layer UX for bounded-length fields:

- **HTML** `maxlength` — hard input ceiling at type time
- **JS char counter** (`attachCharCounter`) — primary UX hint: live
  "actual / max" rendered under the field, codepoint-aware to match
  backend `chars().count()`
- **JS validation message** (`showMaxLengthError`) — submit-time
  fallback, only fires when the HTML limit is bypassed (paste,
  DevTools, programmatic entry)
- **Rust** services keep length checks as a defense-in-depth backstop
  with English raw strings (matches PR #44). The frontend recognizes
  these and re-renders the localized version.

Toast was originally planned for "Inline + Toast" UX but
investigation revealed there is no toast component in the codebase.
Deferred to issue #45 to avoid out-of-proportion scope.

## Changes

| File | Change |
|---|---|
| `src/services/shop.rs` | chars-based length checks in `add_shop` / `update_shop`; 6 new multibyte boundary tests |
| `src/consts.rs` | drop `#[allow(dead_code)]` from `MAX_NAME_LEN` |
| `res/js/consts.js` | mirror the 5 length constants for JS-side use |
| `res/shop-management.html` | `maxlength=128` on `#shop-name`, `maxlength=1000` on `#shop-memo` |
| `res/js/shop-management.js` | wire validation helpers + attach char counters; modal onOpen dispatches synthetic input event to refresh counters after programmatic value changes |
| `res/js/validation-display.js` | add `attachCharCounter()` (codepoint-aware live counter, returns detach fn); refactor `findErrorElement` to walk forward so counter & error can coexist as siblings |
| `CLAUDE.md` | doc fix: frontend test command path is `res/tests`, not `res` |

### Bonus fix

The existing `saveShop()` error path called
`document.getElementById('shop-name-error').textContent = ...` for an
element that does not exist in `shop-management.html` — the reference
was broken (TypeError on null). Replaced with `showValidationError()`
against the input element. Same treatment for the empty-name
validation. Scope-aligned: the same function was being restructured.

## Test plan

- [x] `cargo test --lib`: 321 pass, 0 fail (6 new shop tests, all 13
      shop tests pass)
- [x] `cargo clippy --lib --tests`: no new warnings on shop.rs
- [x] `npm test` (res/tests, Jest): 609 pass / 4 skipped, 15 suites all
      green after `validation-display.js` refactor
- [x] Manual smoke test (shop modal):
  - Open shop modal → counters show `0 / 128` and `0 / 1000`
  - Type/edit → counters tick live
  - Edit mode preload → counters reflect existing value immediately
  - Multibyte (`あいう`) and emoji (`🍣`) each count as 1 (matches
    backend `chars().count()`)
- [ ] Edge case (defense-in-depth path): bypass maxlength via DevTools
      and submit → Rust returns error, JS re-renders the localized
      message

## Out of scope (future PRs)

- Same treatment for `account` / `manufacturer` / `product` /
  `category` / `recurring` / `user_management` services
- Toast notification component → issue #45
- Jest unit tests for `validation-display.js` (DOM ops in jsdom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
