### PR TITLE
feat(validation): bounded-field validation for transaction/recurring/category/user_management (#37 Phase 2-3 part 2)

### DIFF
--- a/res/category-management.html
+++ b/res/category-management.html
@@ -86,12 +86,12 @@
                         
                         <div class="form-group">
                             <label for="category1-name-ja" data-i18n="category_mgmt.name_ja">Name (Japanese):</label>
-                            <input type="text" id="category1-name-ja" required />
+                            <input type="text" id="category1-name-ja" maxlength="256" required />
                         </div>
                         
                         <div class="form-group">
                             <label for="category1-name-en" data-i18n="category_mgmt.name_en">Name (English):</label>
-                            <input type="text" id="category1-name-en" required />
+                            <input type="text" id="category1-name-en" maxlength="256" required />
                         </div>
                         
                         <div class="form-group">
@@ -126,12 +126,12 @@
                         
                         <div class="form-group">
                             <label for="category2-name-ja" data-i18n="category_mgmt.name_ja">Name (Japanese):</label>
-                            <input type="text" id="category2-name-ja" required />
+                            <input type="text" id="category2-name-ja" maxlength="256" required />
                         </div>
                         
                         <div class="form-group">
                             <label for="category2-name-en" data-i18n="category_mgmt.name_en">Name (English):</label>
-                            <input type="text" id="category2-name-en" required />
+                            <input type="text" id="category2-name-en" maxlength="256" required />
                         </div>
                     </form>
                 </div>
@@ -161,12 +161,12 @@
                         
                         <div class="form-group">
                             <label for="category3-name-ja" data-i18n="category_mgmt.name_ja">Name (Japanese):</label>
-                            <input type="text" id="category3-name-ja" required />
+                            <input type="text" id="category3-name-ja" maxlength="256" required />
                         </div>
                         
                         <div class="form-group">
                             <label for="category3-name-en" data-i18n="category_mgmt.name_en">Name (English):</label>
-                            <input type="text" id="category3-name-en" required />
+                            <input type="text" id="category3-name-en" maxlength="256" required />
                         </div>
                     </form>
                 </div>

--- a/res/js/category-management.js
+++ b/res/js/category-management.js
@@ -6,6 +6,8 @@ import { Modal } from './modal.js';
 import { HTML_FILES } from './html-files.js';
 import { getCurrentSessionUser, isSessionAuthenticated } from './session.js';
 import { createMenuBar } from './menu.js';
+import { showValidationError, clearValidationError, showMaxLengthError, attachCharCounter } from './validation-display.js';
+import { MAX_I18N_NAME_LEN } from './consts.js';
 
 // Category level constants
 const LEVEL_CATEGORY1 = 1;
@@ -101,6 +103,11 @@ document.addEventListener('DOMContentLoaded', async function() {
 });
 
 function initModals() {
+    // Wire bounded-field counters + live error clearing for all 6 i18n name
+    // inputs (cat1/cat2/cat3 × ja/en). Counters survive multiple modal
+    // open/close cycles thanks to attachCharCounter's idempotent guard.
+    setupCategoryNameCounters();
+
     // Initialize Category2 Modal
     category2Modal = new Modal('category2-modal', {
         formId: 'category2-form',
@@ -112,22 +119,31 @@ function initModals() {
             const parentNameField = document.getElementById('category2-parent-name');
             const nameJaField = document.getElementById('category2-name-ja');
             const nameEnField = document.getElementById('category2-name-en');
-            
+
             // Set title
-            title.textContent = mode === 'add' ? 
-                i18n.t('category_mgmt.add_category2') : 
+            title.textContent = mode === 'add' ?
+                i18n.t('category_mgmt.add_category2') :
                 i18n.t('category_mgmt.edit_category2');
-            
+
             // Find parent category name
             const parentCategory = categories.find(cat => cat.category1.category1_code === data.category1Code);
             const parentName = parentCategory ? parentCategory.category1.category1_name_i18n : data.category1Code;
             parentNameField.value = parentName;
-            
+
             // Set values for edit mode
             if (mode === 'edit') {
                 nameJaField.value = data.nameJa || '';
                 nameEnField.value = data.nameEn || '';
+            } else {
+                nameJaField.value = '';
+                nameEnField.value = '';
             }
+
+            // Clear validation errors and refresh counters after programmatic value changes.
+            clearValidationError(nameJaField);
+            clearValidationError(nameEnField);
+            nameJaField.dispatchEvent(new Event('input'));
+            nameEnField.dispatchEvent(new Event('input'));
         },
         onSave: async (formData) => {
             await handleCategory2Save(formData);
@@ -145,12 +161,12 @@ function initModals() {
             const parentNameField = document.getElementById('category3-parent-name');
             const nameJaField = document.getElementById('category3-name-ja');
             const nameEnField = document.getElementById('category3-name-en');
-            
+
             // Set title
-            title.textContent = mode === 'add' ? 
-                i18n.t('category_mgmt.add_category3') : 
+            title.textContent = mode === 'add' ?
+                i18n.t('category_mgmt.add_category3') :
                 i18n.t('category_mgmt.edit_category3');
-            
+
             // Find parent category name
             let parentName = data.category2Code;
             const parentCategory1 = categories.find(cat => cat.category1.category1_code === data.category1Code);
@@ -161,17 +177,40 @@ function initModals() {
                 }
             }
             parentNameField.value = parentName;
-            
+
             // Set values for edit mode
             if (mode === 'edit') {
                 nameJaField.value = data.nameJa || '';
                 nameEnField.value = data.nameEn || '';
+            } else {
+                nameJaField.value = '';
+                nameEnField.value = '';
             }
+
+            // Clear validation errors and refresh counters after programmatic value changes.
+            clearValidationError(nameJaField);
+            clearValidationError(nameEnField);
+            nameJaField.dispatchEvent(new Event('input'));
+            nameEnField.dispatchEvent(new Event('input'));
         },
         onSave: async (formData) => {
             await handleCategory3Save(formData);
         }
     });
+}
+
+function setupCategoryNameCounters() {
+    const ids = [
+        'category1-name-ja', 'category1-name-en',
+        'category2-name-ja', 'category2-name-en',
+        'category3-name-ja', 'category3-name-en',
+    ];
+    for (const id of ids) {
+        const el = document.getElementById(id);
+        if (!el) continue;
+        attachCharCounter(el, MAX_I18N_NAME_LEN);
+        el.addEventListener('input', () => clearValidationError(el));
+    }
 }
 
 
@@ -740,10 +779,15 @@ async function handleCategory2Save(formData) {
     const mode = formData.mode;
     const category1Code = formData.category1Code;
     const category2Code = formData.category2Code;
-    
-    let nameJa = document.getElementById('category2-name-ja').value.trim();
-    let nameEn = document.getElementById('category2-name-en').value.trim();
-    
+
+    const nameJaField = document.getElementById('category2-name-ja');
+    const nameEnField = document.getElementById('category2-name-en');
+    let nameJa = nameJaField.value.trim();
+    let nameEn = nameEnField.value.trim();
+
+    clearValidationError(nameJaField);
+    clearValidationError(nameEnField);
+
     // If one is empty, copy from the other
     if (!nameJa && !nameEn) {
         alert(i18n.t('error.category_name_required'));
@@ -751,6 +795,16 @@ async function handleCategory2Save(formData) {
     }
     if (!nameJa) nameJa = nameEn;
     if (!nameEn) nameEn = nameJa;
+
+    // Bounded-field max-length checks (mirror Rust defense in src/services/category.rs).
+    if ([...nameJa].length > MAX_I18N_NAME_LEN) {
+        showMaxLengthError(nameJaField, i18n.t('category_mgmt.name_ja'), MAX_I18N_NAME_LEN);
+        throw new Error('Validation error: category name (ja) too long');
+    }
+    if ([...nameEn].length > MAX_I18N_NAME_LEN) {
+        showMaxLengthError(nameEnField, i18n.t('category_mgmt.name_en'), MAX_I18N_NAME_LEN);
+        throw new Error('Validation error: category name (en) too long');
+    }
     
     // Disable save button and show loading state
     const saveButton = document.querySelector('#category2-modal .btn-primary');
@@ -778,10 +832,30 @@ async function handleCategory2Save(formData) {
         await loadCategories();
     } catch (error) {
         console.error('Failed to save category2:', error);
-        
+
+        const errStr = String(error);
+
+        // Defense-line trip from Rust: bounded-field max length.
+        if (errStr.includes('Japanese name must be')) {
+            showValidationError(nameJaField, i18n.t('validation.max_length', {
+                field: i18n.t('category_mgmt.name_ja'),
+                max: MAX_I18N_NAME_LEN,
+                actual: [...nameJa].length,
+            }));
+            throw error;
+        }
+        if (errStr.includes('English name must be')) {
+            showValidationError(nameEnField, i18n.t('validation.max_length', {
+                field: i18n.t('category_mgmt.name_en'),
+                max: MAX_I18N_NAME_LEN,
+                actual: [...nameEn].length,
+            }));
+            throw error;
+        }
+
         // Check if it's a duplicate name error
-        if (error.includes('already exists')) {
-            const match = error.match(/Category name '(.+)' already exists/);
+        if (errStr.includes('already exists')) {
+            const match = errStr.match(/Category name '(.+)' already exists/);
             const duplicateName = match ? match[1] : '';
             const errorMsg = i18n.t('error.category_duplicate_name').replace('{0}', duplicateName);
             alert(errorMsg);
@@ -801,10 +875,15 @@ async function handleCategory3Save(formData) {
     const category1Code = formData.category1Code;
     const category2Code = formData.category2Code;
     const category3Code = formData.category3Code;
-    
-    let nameJa = document.getElementById('category3-name-ja').value.trim();
-    let nameEn = document.getElementById('category3-name-en').value.trim();
-    
+
+    const nameJaField = document.getElementById('category3-name-ja');
+    const nameEnField = document.getElementById('category3-name-en');
+    let nameJa = nameJaField.value.trim();
+    let nameEn = nameEnField.value.trim();
+
+    clearValidationError(nameJaField);
+    clearValidationError(nameEnField);
+
     // If one is empty, copy from the other
     if (!nameJa && !nameEn) {
         alert(i18n.t('error.category_name_required'));
@@ -812,6 +891,16 @@ async function handleCategory3Save(formData) {
     }
     if (!nameJa) nameJa = nameEn;
     if (!nameEn) nameEn = nameJa;
+
+    // Bounded-field max-length checks (mirror Rust defense in src/services/category.rs).
+    if ([...nameJa].length > MAX_I18N_NAME_LEN) {
+        showMaxLengthError(nameJaField, i18n.t('category_mgmt.name_ja'), MAX_I18N_NAME_LEN);
+        throw new Error('Validation error: category name (ja) too long');
+    }
+    if ([...nameEn].length > MAX_I18N_NAME_LEN) {
+        showMaxLengthError(nameEnField, i18n.t('category_mgmt.name_en'), MAX_I18N_NAME_LEN);
+        throw new Error('Validation error: category name (en) too long');
+    }
     
     // Disable save button and show loading state
     const saveButton = document.querySelector('#category3-modal .btn-primary');
@@ -841,10 +930,30 @@ async function handleCategory3Save(formData) {
         await loadCategories();
     } catch (error) {
         console.error('Failed to save category3:', error);
-        
+
+        const errStr = String(error);
+
+        // Defense-line trip from Rust: bounded-field max length.
+        if (errStr.includes('Japanese name must be')) {
+            showValidationError(nameJaField, i18n.t('validation.max_length', {
+                field: i18n.t('category_mgmt.name_ja'),
+                max: MAX_I18N_NAME_LEN,
+                actual: [...nameJa].length,
+            }));
+            throw error;
+        }
+        if (errStr.includes('English name must be')) {
+            showValidationError(nameEnField, i18n.t('validation.max_length', {
+                field: i18n.t('category_mgmt.name_en'),
+                max: MAX_I18N_NAME_LEN,
+                actual: [...nameEn].length,
+            }));
+            throw error;
+        }
+
         // Check if it's a duplicate name error
-        if (error.includes('already exists')) {
-            const match = error.match(/Category name '(.+)' already exists/);
+        if (errStr.includes('already exists')) {
+            const match = errStr.match(/Category name '(.+)' already exists/);
             const duplicateName = match ? match[1] : '';
             const errorMsg = i18n.t('error.category_duplicate_name').replace('{0}', duplicateName);
             alert(errorMsg);

--- a/res/js/recurring-rule.js
+++ b/res/js/recurring-rule.js
@@ -6,6 +6,8 @@ import { setupIndicators } from './indicators.js';
 import { getCurrentSessionUser, isSessionAuthenticated } from './session.js';
 import { createMenuBar, setupLanguageMenu, setupLanguageMenuHandlers } from './menu.js';
 import { setupTaxCalculationListeners } from './detail-tax-calc.js';
+import { showValidationError, clearValidationError, showMaxLengthError, attachCharCounter } from './validation-display.js';
+import { MAX_RULE_NAME_LEN, MAX_ITEM_NAME_LEN, MAX_MEMO_LEN } from './consts.js';
 
 console.log('=== RECURRING-RULE.JS LOADED ===');
 
@@ -46,6 +48,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         setupCycleKindToggle();
         setupCategoryChainHandlers();
         setupDetailTaxCalculation();
+        setupBoundedFieldCounters();
         setupFormSubmit();
         setupResetButton();
         setupDeleteModal();
@@ -311,6 +314,39 @@ function setupFormSubmit() {
             return;
         }
 
+        // Bounded-field max-length checks (mirror Rust defense in
+        // src/services/recurring.rs::create_rule_with_instances).
+        const ruleNameInput = document.getElementById('rule-name');
+        const headerMemoInput = document.getElementById('header-memo');
+        const itemNameInput = document.getElementById('item-name');
+        const detailMemoInput = document.getElementById('detail-memo');
+        clearValidationError(ruleNameInput);
+        clearValidationError(headerMemoInput);
+        clearValidationError(itemNameInput);
+        clearValidationError(detailMemoInput);
+
+        const ruleName = request.rule_name || '';
+        const headerMemo = request.header_memo || '';
+        const itemName = request.detail.item_name;
+        const detailMemo = request.detail.detail_memo || '';
+
+        if ([...ruleName].length > MAX_RULE_NAME_LEN) {
+            showMaxLengthError(ruleNameInput, i18n.t('recurring_rule.rule_name'), MAX_RULE_NAME_LEN);
+            return;
+        }
+        if ([...itemName].length > MAX_ITEM_NAME_LEN) {
+            showMaxLengthError(itemNameInput, i18n.t('recurring_rule.item_name'), MAX_ITEM_NAME_LEN);
+            return;
+        }
+        if ([...headerMemo].length > MAX_MEMO_LEN) {
+            showMaxLengthError(headerMemoInput, i18n.t('recurring_rule.header_memo'), MAX_MEMO_LEN);
+            return;
+        }
+        if ([...detailMemo].length > MAX_MEMO_LEN) {
+            showMaxLengthError(detailMemoInput, i18n.t('recurring_rule.detail_memo'), MAX_MEMO_LEN);
+            return;
+        }
+
         try {
             const result = await invoke('create_recurring_rule', { request });
             const tmpl = i18n.t('recurring_rule.create_success') || 'Created rule #{0} with {1} occurrences.';
@@ -321,6 +357,26 @@ function setupFormSubmit() {
             await loadRules();
         } catch (err) {
             console.error('create_recurring_rule failed:', err);
+
+            // Map Rust bounded-field errors back to inline validation messages.
+            const errStr = String(err);
+            const map = [
+                ['Rule name must be', ruleNameInput, 'recurring_rule.rule_name', MAX_RULE_NAME_LEN, ruleName],
+                ['Item name must be', itemNameInput, 'recurring_rule.item_name', MAX_ITEM_NAME_LEN, itemName],
+                ['Header memo must be', headerMemoInput, 'recurring_rule.header_memo', MAX_MEMO_LEN, headerMemo],
+                ['Detail memo must be', detailMemoInput, 'recurring_rule.detail_memo', MAX_MEMO_LEN, detailMemo],
+            ];
+            for (const [needle, input, fieldKey, max, value] of map) {
+                if (input && errStr.includes(needle)) {
+                    showValidationError(input, i18n.t('validation.max_length', {
+                        field: i18n.t(fieldKey),
+                        max,
+                        actual: [...value].length,
+                    }));
+                    return;
+                }
+            }
+
             const prefix = i18n.t('recurring_rule.create_failed') || 'Failed to create rule:';
             showResult('error', `${prefix} ${err}`);
         }
@@ -331,7 +387,39 @@ function setupResetButton() {
     document.getElementById('reset-btn').addEventListener('click', () => {
         document.getElementById('recurring-rule-form').reset();
         hideResult();
+        // form.reset() does not fire 'input', so refresh counters manually.
+        ['rule-name', 'header-memo', 'item-name', 'detail-memo'].forEach((id) => {
+            const el = document.getElementById(id);
+            if (el) {
+                clearValidationError(el);
+                el.dispatchEvent(new Event('input'));
+            }
+        });
     });
+}
+
+function setupBoundedFieldCounters() {
+    const ruleName = document.getElementById('rule-name');
+    const headerMemo = document.getElementById('header-memo');
+    const itemName = document.getElementById('item-name');
+    const detailMemo = document.getElementById('detail-memo');
+
+    if (ruleName) {
+        attachCharCounter(ruleName, MAX_RULE_NAME_LEN);
+        ruleName.addEventListener('input', () => clearValidationError(ruleName));
+    }
+    if (headerMemo) {
+        attachCharCounter(headerMemo, MAX_MEMO_LEN);
+        headerMemo.addEventListener('input', () => clearValidationError(headerMemo));
+    }
+    if (itemName) {
+        attachCharCounter(itemName, MAX_ITEM_NAME_LEN);
+        itemName.addEventListener('input', () => clearValidationError(itemName));
+    }
+    if (detailMemo) {
+        attachCharCounter(detailMemo, MAX_MEMO_LEN);
+        detailMemo.addEventListener('input', () => clearValidationError(detailMemo));
+    }
 }
 
 // ----- Rule list -----

--- a/res/js/transaction-detail-management.js
+++ b/res/js/transaction-detail-management.js
@@ -4,11 +4,12 @@ import { setupIndicators } from './indicators.js';
 import { setupFontSizeMenuHandlers, setupFontSizeMenu, applyFontSize, setupFontSizeModalHandlers, adjustWindowSize } from './font-size.js';
 import { setupLanguageMenuHandlers, setupLanguageMenu, handleLogout, handleQuit } from './menu.js';
 import { HTML_FILES } from './html-files.js';
-import { ROLE_ADMIN } from './consts.js';
+import { ROLE_ADMIN, MAX_ITEM_NAME_LEN, MAX_MEMO_LEN } from './consts.js';
 import { getCurrentSessionUser, isSessionAuthenticated } from './session.js';
 import { createMenuBar } from './menu.js';
 import { applyHeaderRecalculationPrompt } from './header-recalc.js';
 import { setupTaxCalculationListeners } from './detail-tax-calc.js';
+import { showValidationError, clearValidationError, showMaxLengthError, attachCharCounter } from './validation-display.js';
 
 let currentUserId = null;
 let currentUserRole = null;
@@ -283,6 +284,14 @@ function setupEventListeners() {
     
     // Tax calculation listeners (shared module)
     installTaxCalculationListeners();
+
+    // Live-clear validation errors as the user edits + character counters
+    const itemNameInput = document.getElementById('item-name');
+    const memoInput = document.getElementById('memo');
+    itemNameInput?.addEventListener('input', () => clearValidationError(itemNameInput));
+    memoInput?.addEventListener('input', () => clearValidationError(memoInput));
+    if (itemNameInput) attachCharCounter(itemNameInput, MAX_ITEM_NAME_LEN);
+    if (memoInput) attachCharCounter(memoInput, MAX_MEMO_LEN);
     
     // Category2 change listener
     const category2Select = document.getElementById('category2-code');
@@ -585,6 +594,15 @@ async function openDetailModal(detail = null) {
     const modalContent = modal.querySelector('.modal-content');
     if (modalContent) modalContent.scrollTop = 0;
 
+    // Clear validation errors and refresh char counters after programmatic
+    // value changes (form.reset() / direct .value assignments do not fire 'input').
+    const itemNameInput = document.getElementById('item-name');
+    const memoInput = document.getElementById('memo');
+    clearValidationError(itemNameInput);
+    clearValidationError(memoInput);
+    itemNameInput?.dispatchEvent(new Event('input'));
+    memoInput?.dispatchEvent(new Event('input'));
+
     // Focus on item name input after modal opens (preventScroll to avoid modal shifting)
     setTimeout(() => document.getElementById('item-name')?.focus({ preventScroll: true }), 0);
 }
@@ -598,9 +616,11 @@ function closeDetailModal() {
 
 async function handleDetailFormSubmit(event) {
     event.preventDefault();
-    
+
     const detailId = document.getElementById('detail-id').value;
-    const itemName = document.getElementById('item-name').value.trim();
+    const itemNameInput = document.getElementById('item-name');
+    const memoInput = document.getElementById('memo');
+    const itemName = itemNameInput.value.trim();
     const category1Code = document.getElementById('category1-code').value;
     const category2Code = document.getElementById('category2-code').value;
     const category3Code = document.getElementById('category3-code').value;
@@ -608,19 +628,32 @@ async function handleDetailFormSubmit(event) {
     const amountIncludingTax = parseInt(document.getElementById('amount-including-tax').value) || 0;
     const taxRate = parseInt(document.getElementById('tax-rate').value) || 0;
     const taxAmount = parseInt(document.getElementById('tax-amount').value) || 0;
-    const memo = document.getElementById('memo').value.trim();
-    
+    const memo = memoInput.value.trim();
+
+    clearValidationError(itemNameInput);
+    clearValidationError(memoInput);
+
     // Validation
     if (!itemName) {
-        showMessage('error', i18n.t('detail_mgmt.error_item_name_required'));
+        showValidationError(itemNameInput, i18n.t('detail_mgmt.error_item_name_required'));
         return;
     }
-    
+
+    // Validation — max length (mirrors Rust defense in src/services/transaction.rs)
+    if ([...itemName].length > MAX_ITEM_NAME_LEN) {
+        showMaxLengthError(itemNameInput, i18n.t('detail_mgmt.item_name'), MAX_ITEM_NAME_LEN);
+        return;
+    }
+    if (memo && [...memo].length > MAX_MEMO_LEN) {
+        showMaxLengthError(memoInput, i18n.t('detail_mgmt.memo'), MAX_MEMO_LEN);
+        return;
+    }
+
     if (!category1Code) {
         showMessage('error', i18n.t('detail_mgmt.error_category_required'));
         return;
     }
-    
+
     if (amountExcludingTax < 0 || amountIncludingTax < 0) {
         showMessage('error', i18n.t('detail_mgmt.error_invalid_amount'));
         return;
@@ -672,6 +705,27 @@ async function handleDetailFormSubmit(event) {
         
     } catch (error) {
         console.error('Failed to save detail:', error);
+
+        // Map backend error messages to i18n resources / localized text.
+        // Rust defense line for bounded fields (src/services/transaction.rs).
+        const errorMessage = error.toString();
+        if (errorMessage.includes('Item name must be')) {
+            showValidationError(itemNameInput, i18n.t('validation.max_length', {
+                field: i18n.t('detail_mgmt.item_name'),
+                max: MAX_ITEM_NAME_LEN,
+                actual: [...itemName].length,
+            }));
+            return;
+        }
+        if (errorMessage.includes('Memo must be')) {
+            showValidationError(memoInput, i18n.t('validation.max_length', {
+                field: i18n.t('detail_mgmt.memo'),
+                max: MAX_MEMO_LEN,
+                actual: [...memo].length,
+            }));
+            return;
+        }
+
         showMessage('error', `${i18n.t('detail_mgmt.save_error')}: ${error.message}`);
     }
 }

--- a/res/js/transaction-management.js
+++ b/res/js/transaction-management.js
@@ -4,12 +4,13 @@ import { setupIndicators } from './indicators.js';
 import { setupFontSizeMenuHandlers, setupFontSizeMenu, applyFontSize, setupFontSizeModalHandlers, adjustWindowSize } from './font-size.js';
 import { setupLanguageMenuHandlers, setupLanguageMenu, handleLogout, handleQuit } from './menu.js';
 import { HTML_FILES } from './html-files.js';
-import { TAX_ROUND_DOWN, TAX_ROUND_HALF_UP, TAX_ROUND_UP, ROLE_ADMIN, ROLE_USER } from './consts.js';
+import { TAX_ROUND_DOWN, TAX_ROUND_HALF_UP, TAX_ROUND_UP, ROLE_ADMIN, ROLE_USER, MAX_MEMO_LEN } from './consts.js';
 import { Modal } from './modal.js';
 import { getCurrentSessionUser, isSessionAuthenticated, setSessionSourceScreen, getSessionModalState, setSessionModalState, clearSessionModalState } from './session.js';
 import { createMenuBar } from './menu.js';
 import { applyHeaderRecalculationPrompt } from './header-recalc.js';
 import { calculateRecommendedTotal } from './tax-calc.js';
+import { showValidationError, clearValidationError, showMaxLengthError, attachCharCounter } from './validation-display.js';
 
 let currentUserId = null;
 let currentUserRole = null;
@@ -182,12 +183,17 @@ function setupEventListeners() {
     // Add transaction button
     const addTransactionBtn = document.getElementById('add-transaction-btn');
     addTransactionBtn.addEventListener('click', openTransactionModal);
-    
+
     // Initialize transaction modal with common Modal class
     initializeTransactionModal();
-    
+
     // Setup spinner buttons for amount range filters
     setupAmountSpinners();
+
+    // Live-clear validation errors as the user edits + character counter
+    const memoInput = document.getElementById('transaction-memo');
+    memoInput?.addEventListener('input', () => clearValidationError(memoInput));
+    if (memoInput) attachCharCounter(memoInput, MAX_MEMO_LEN);
 }
 
 function setupAmountSpinners() {
@@ -638,6 +644,13 @@ function initializeTransactionModal() {
             if (mode === 'edit' && data.transactionId && typeof data.transactionId === 'number') {
                 await loadTransactionData(data.transactionId);
             }
+
+            // Clear validation error and refresh char counter after
+            // programmatic value changes (form.reset() / loadTransactionData
+            // do not fire 'input').
+            const memoInput = document.getElementById('transaction-memo');
+            clearValidationError(memoInput);
+            memoInput?.dispatchEvent(new Event('input'));
         },
         onSave: async (formData) => {
             await handleTransactionSubmit(new Event('submit'));
@@ -907,7 +920,7 @@ function handleCategory1Change(event) {
 
 async function handleTransactionSubmit(event) {
     event.preventDefault();
-    
+
     const transactionDateInput = document.getElementById('transaction-date').value;
     const shopIdValue = document.getElementById('shop').value;
     const shopId = shopIdValue ? parseInt(shopIdValue) : null;
@@ -917,8 +930,17 @@ async function handleTransactionSubmit(event) {
     const totalAmount = parseInt(document.getElementById('total-amount').value);
     const taxRoundingValue = parseInt(document.getElementById('tax-rounding').value);
     const taxIncludedTypeValue = parseInt(document.getElementById('tax-included-type').value);
-    const memoText = document.getElementById('transaction-memo').value.trim() || null;
+    const memoInput = document.getElementById('transaction-memo');
+    const memoRaw = memoInput.value.trim();
+    const memoText = memoRaw || null;
     const isScheduled = document.getElementById('is-scheduled').checked ? 1 : 0;
+
+    // Validation — max memo length (mirrors Rust defense in src/services/transaction.rs)
+    clearValidationError(memoInput);
+    if (memoRaw && [...memoRaw].length > MAX_MEMO_LEN) {
+        showMaxLengthError(memoInput, i18n.t('transaction_mgmt.memo'), MAX_MEMO_LEN);
+        throw new Error('Validation error: memo too long');
+    }
 
     // Convert datetime-local format (YYYY-MM-DDTHH:mm) to SQLite DATETIME format (YYYY-MM-DD HH:MM:SS)
     const transactionDate = transactionDateInput.replace('T', ' ') + ':00';
@@ -983,6 +1005,19 @@ async function handleTransactionSubmit(event) {
         
     } catch (error) {
         console.error('Failed to save transaction:', error);
+
+        // Map backend error messages to i18n resources / localized text.
+        // Rust defense line for bounded fields (src/services/transaction.rs).
+        const errorMessage = error.toString();
+        if (errorMessage.includes('Memo must be')) {
+            showValidationError(memoInput, i18n.t('validation.max_length', {
+                field: i18n.t('transaction_mgmt.memo'),
+                max: MAX_MEMO_LEN,
+                actual: [...memoRaw].length,
+            }));
+            throw error;
+        }
+
         alert('Failed to save transaction: ' + error);
     }
 }

--- a/res/js/user-management.js
+++ b/res/js/user-management.js
@@ -1,12 +1,13 @@
 import { invoke } from '@tauri-apps/api/core';
 import i18n from './i18n.js';
-import { ROLE_ADMIN, ROLE_USER } from './consts.js';
+import { ROLE_ADMIN, ROLE_USER, MAX_NAME_LEN } from './consts.js';
 import { setupIndicators } from './indicators.js';
 import { setupFontSizeMenuHandlers, setupFontSizeMenu, applyFontSize, setupFontSizeModalHandlers, adjustWindowSize } from './font-size.js';
 import { HTML_FILES } from './html-files.js';
 import { Modal } from './modal.js';
 import { getCurrentSessionUser, isSessionAuthenticated } from './session.js';
 import { createMenuBar } from './menu.js';
+import { showValidationError, clearValidationError, showMaxLengthError, attachCharCounter } from './validation-display.js';
 
 let currentUsers = [];
 let editingUserId = null;
@@ -76,6 +77,9 @@ document.addEventListener('DOMContentLoaded', async function() {
 });
 
 function initModals() {
+    // Wire bounded-field counter + live error clearing for the username input.
+    setupUsernameCounter();
+
     // Initialize User Modal
     userModal = new Modal('user-modal', {
         formId: 'user-form',
@@ -87,7 +91,8 @@ function initModals() {
             const passwordConfirmGroup = document.getElementById('password-confirm-group');
             const passwordInput = document.getElementById('password');
             const passwordConfirmInput = document.getElementById('password-confirm');
-            
+            const usernameInput = document.getElementById('username');
+
             if (mode === 'add') {
                 title.textContent = i18n.t('user_mgmt.add_user');
                 passwordGroup.style.display = 'block';
@@ -95,6 +100,7 @@ function initModals() {
                 passwordInput.required = true;
                 passwordConfirmInput.required = true;
                 editingUserId = null;
+                usernameInput.value = '';
             } else if (mode === 'edit') {
                 title.textContent = i18n.t('user_mgmt.edit_user');
                 passwordGroup.style.display = 'none';
@@ -102,10 +108,14 @@ function initModals() {
                 passwordInput.required = false;
                 passwordConfirmInput.required = false;
                 editingUserId = data.userId;
-                
+
                 // Set form values
-                document.getElementById('username').value = data.username;
+                usernameInput.value = data.username;
             }
+
+            // Clear validation errors and refresh counter after programmatic value changes.
+            clearValidationError(usernameInput);
+            usernameInput.dispatchEvent(new Event('input'));
         },
         onSave: async (formData) => {
             await handleUserSave();
@@ -124,6 +134,13 @@ function initModals() {
             await handleUserDelete(formData.userId);
         }
     });
+}
+
+function setupUsernameCounter() {
+    const usernameInput = document.getElementById('username');
+    if (!usernameInput) return;
+    attachCharCounter(usernameInput, MAX_NAME_LEN);
+    usernameInput.addEventListener('input', () => clearValidationError(usernameInput));
 }
 
 
@@ -407,30 +424,51 @@ function closeUserModal() {
 }
 
 async function handleUserSave() {
-    const username = document.getElementById('username').value.trim();
+    const usernameInput = document.getElementById('username');
+    const username = usernameInput.value.trim();
     const password = document.getElementById('password').value;
     const passwordConfirm = document.getElementById('password-confirm').value;
-    
+
+    clearValidationError(usernameInput);
+
+    // Validation — max length (mirrors Rust defense in src/services/user_management.rs)
+    if ([...username].length > MAX_NAME_LEN) {
+        showMaxLengthError(usernameInput, i18n.t('user_mgmt.username'), MAX_NAME_LEN);
+        throw new Error('Validation error: username too long');
+    }
+
     if (password && password !== passwordConfirm) {
         showMessage('form-message', i18n.t('error.password_mismatch'), 'error');
         throw new Error('Password mismatch');
     }
-    
+
     if (password && password.length < 16) {
         showMessage('form-message', i18n.t('error.password_too_short'), 'error');
         throw new Error('Password too short');
     }
-    
+
     try {
         if (editingUserId) {
             await updateUser(editingUserId, username, password || null);
         } else {
             await createUser(username, password);
         }
-        
+
         await loadUsers();
     } catch (error) {
         console.error('Failed to save user:', error);
+
+        // Defense-line trip from Rust: bounded-field max length.
+        const errStr = String(error);
+        if (errStr.includes('Username must be')) {
+            showValidationError(usernameInput, i18n.t('validation.max_length', {
+                field: i18n.t('user_mgmt.username'),
+                max: MAX_NAME_LEN,
+                actual: [...username].length,
+            }));
+            throw error;
+        }
+
         showMessage('form-message', i18n.t('error.save_user_failed') + ': ' + error, 'error');
         throw error;
     }

--- a/res/transaction-detail-management.html
+++ b/res/transaction-detail-management.html
@@ -130,7 +130,7 @@
                     <div class="form-group">
                         <label for="item-name" data-i18n="detail_mgmt.item_name">Item Name:</label>
                         <div class="input-wrapper">
-                            <input type="text" id="item-name" name="item-name" required />
+                            <input type="text" id="item-name" name="item-name" maxlength="200" required />
                         </div>
                     </div>
 
@@ -187,7 +187,7 @@
                     <div class="form-group">
                         <label for="memo" data-i18n="detail_mgmt.memo">Memo:</label>
                         <div class="input-wrapper">
-                            <textarea id="memo" name="memo" rows="3"></textarea>
+                            <textarea id="memo" name="memo" rows="3" maxlength="1000"></textarea>
                         </div>
                     </div>
 

--- a/res/transaction-management.html
+++ b/res/transaction-management.html
@@ -241,7 +241,7 @@
 
                         <div class="form-group">
                             <label for="transaction-memo" data-i18n="transaction_mgmt.memo">Memo:</label>
-                            <textarea id="transaction-memo" rows="3"></textarea>
+                            <textarea id="transaction-memo" rows="3" maxlength="1000"></textarea>
                         </div>
 
                         <div class="form-group">

--- a/res/user-management.html
+++ b/res/user-management.html
@@ -63,7 +63,7 @@
                             <div class="form-group">
                                 <label for="username" data-i18n="user_mgmt.username">Username:</label>
                                 <div class="input-wrapper">
-                                    <input type="text" id="username" name="username" required />
+                                    <input type="text" id="username" name="username" maxlength="128" required />
                                 </div>
                             </div>
                             <div class="form-group" id="password-group">

--- a/src/services/category.rs
+++ b/src/services/category.rs
@@ -1,11 +1,12 @@
 use sqlx::sqlite::SqlitePool;
 use sqlx::Row;
-use crate::sql_queries;
+use crate::{sql_queries, consts};
 
 #[derive(Debug)]
 pub enum CategoryError {
     DatabaseError(sqlx::Error),
     DuplicateName(String),
+    Validation(String),
 }
 
 impl std::fmt::Display for CategoryError {
@@ -13,6 +14,7 @@ impl std::fmt::Display for CategoryError {
         match self {
             CategoryError::DatabaseError(e) => write!(f, "Database error: {}", e),
             CategoryError::DuplicateName(name) => write!(f, "Category name '{}' already exists", name),
+            CategoryError::Validation(msg) => write!(f, "{}", msg),
         }
     }
 }
@@ -23,6 +25,20 @@ impl From<sqlx::Error> for CategoryError {
     fn from(err: sqlx::Error) -> Self {
         CategoryError::DatabaseError(err)
     }
+}
+
+/// Issue #37 Phase 2-3 — bounded-field length guard for category i18n
+/// name columns (`CATEGORY*_I18N.*_NAME_I18N`). Counts characters, not
+/// bytes, so Japanese input is not implicitly clipped to ~85 chars.
+fn validate_i18n_name_length(name: &str, label: &str) -> Result<(), CategoryError> {
+    if name.chars().count() > consts::MAX_I18N_NAME_LEN {
+        return Err(CategoryError::Validation(format!(
+            "{} must be {} characters or less",
+            label,
+            consts::MAX_I18N_NAME_LEN
+        )));
+    }
+    Ok(())
 }
 
 pub struct CategoryService {
@@ -332,6 +348,9 @@ impl CategoryService {
         category2_name_ja: &str,
         category2_name_en: &str,
     ) -> Result<String, CategoryError> {
+        validate_i18n_name_length(category2_name_ja, "Japanese name")?;
+        validate_i18n_name_length(category2_name_en, "English name")?;
+
         // Check for duplicate Japanese name
         let count_ja: i64 = sqlx::query_scalar(sql_queries::CATEGORY2_CHECK_DUPLICATE_NAME)
             .bind(user_id)
@@ -448,6 +467,9 @@ impl CategoryService {
         category3_name_ja: &str,
         category3_name_en: &str,
     ) -> Result<String, CategoryError> {
+        validate_i18n_name_length(category3_name_ja, "Japanese name")?;
+        validate_i18n_name_length(category3_name_en, "English name")?;
+
         // Check for duplicate Japanese name
         let count_ja: i64 = sqlx::query_scalar(sql_queries::CATEGORY3_CHECK_DUPLICATE_NAME)
             .bind(user_id)
@@ -618,6 +640,9 @@ impl CategoryService {
         name_ja: &str,
         name_en: &str,
     ) -> Result<(), CategoryError> {
+        validate_i18n_name_length(name_ja, "Japanese name")?;
+        validate_i18n_name_length(name_en, "English name")?;
+
         // Check for duplicate Japanese name (excluding current category)
         let count_ja: i64 = sqlx::query_scalar(sql_queries::CATEGORY2_CHECK_DUPLICATE_NAME_EXCLUDING)
             .bind(user_id)
@@ -707,6 +732,9 @@ impl CategoryService {
         name_ja: &str,
         name_en: &str,
     ) -> Result<(), CategoryError> {
+        validate_i18n_name_length(name_ja, "Japanese name")?;
+        validate_i18n_name_length(name_en, "English name")?;
+
         // Check for duplicate Japanese name (excluding current category)
         let count_ja: i64 = sqlx::query_scalar(sql_queries::CATEGORY3_CHECK_DUPLICATE_NAME_EXCLUDING)
             .bind(user_id)
@@ -1802,5 +1830,134 @@ mod tests {
         assert_eq!(cat3_edit.code, cat3_code);
         assert_eq!(cat3_edit.name_ja, "米");
         assert_eq!(cat3_edit.name_en, "Rice");
+    }
+
+    // Issue #37 Phase 2-3 — bounded-field length checks must count
+    // characters (not bytes). CATEGORY*_I18N.*_NAME_I18N is VARCHAR(256).
+
+    #[tokio::test]
+    async fn test_add_category2_accepts_max_chars_of_multibyte_name() {
+        let pool = setup_test_db().await;
+        let service = CategoryService::new(pool.clone());
+        let user_id = 2;
+        setup_category1(&pool, user_id).await;
+
+        let result = service.add_category2(
+            user_id,
+            "EXPENSE",
+            &"あ".repeat(consts::MAX_I18N_NAME_LEN),
+            &"a".repeat(consts::MAX_I18N_NAME_LEN),
+        ).await;
+        assert!(result.is_ok(), "expected MAX_I18N_NAME_LEN multibyte chars to be accepted: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn test_add_category2_rejects_over_max_chars_of_multibyte_ja_name() {
+        let pool = setup_test_db().await;
+        let service = CategoryService::new(pool.clone());
+        let user_id = 2;
+        setup_category1(&pool, user_id).await;
+
+        let result = service.add_category2(
+            user_id,
+            "EXPENSE",
+            &"あ".repeat(consts::MAX_I18N_NAME_LEN + 1),
+            "Food",
+        ).await;
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(&consts::MAX_I18N_NAME_LEN.to_string()),
+            "error should reference the limit: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn test_add_category2_rejects_over_max_chars_of_en_name() {
+        let pool = setup_test_db().await;
+        let service = CategoryService::new(pool.clone());
+        let user_id = 2;
+        setup_category1(&pool, user_id).await;
+
+        let result = service.add_category2(
+            user_id,
+            "EXPENSE",
+            "食費",
+            &"a".repeat(consts::MAX_I18N_NAME_LEN + 1),
+        ).await;
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(&consts::MAX_I18N_NAME_LEN.to_string()),
+            "error should reference the limit: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn test_add_category3_rejects_over_max_chars_of_multibyte_ja_name() {
+        let pool = setup_test_db().await;
+        let service = CategoryService::new(pool.clone());
+        let user_id = 2;
+        setup_category1(&pool, user_id).await;
+
+        let cat2_code = service.add_category2(user_id, "EXPENSE", "食費", "Food")
+            .await.unwrap();
+
+        let result = service.add_category3(
+            user_id,
+            "EXPENSE",
+            &cat2_code,
+            &"あ".repeat(consts::MAX_I18N_NAME_LEN + 1),
+            "Rice",
+        ).await;
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(&consts::MAX_I18N_NAME_LEN.to_string()),
+            "error should reference the limit: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn test_update_category2_i18n_rejects_over_max_chars() {
+        let pool = setup_test_db().await;
+        let service = CategoryService::new(pool.clone());
+        let user_id = 2;
+        setup_category1(&pool, user_id).await;
+
+        let cat2_code = service.add_category2(user_id, "EXPENSE", "食費", "Food")
+            .await.unwrap();
+
+        let result = service.update_category2_i18n(
+            user_id,
+            "EXPENSE",
+            &cat2_code,
+            &"あ".repeat(consts::MAX_I18N_NAME_LEN + 1),
+            "Food",
+        ).await;
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(&consts::MAX_I18N_NAME_LEN.to_string()),
+            "error should reference the limit: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn test_update_category3_i18n_rejects_over_max_chars() {
+        let pool = setup_test_db().await;
+        let service = CategoryService::new(pool.clone());
+        let user_id = 2;
+        setup_category1(&pool, user_id).await;
+
+        let cat2_code = service.add_category2(user_id, "EXPENSE", "食費", "Food")
+            .await.unwrap();
+        let cat3_code = service.add_category3(user_id, "EXPENSE", &cat2_code, "米", "Rice")
+            .await.unwrap();
+
+        let result = service.update_category3_i18n(
+            user_id,
+            "EXPENSE",
+            &cat2_code,
+            &cat3_code,
+            "米",
+            &"a".repeat(consts::MAX_I18N_NAME_LEN + 1),
+        ).await;
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(&consts::MAX_I18N_NAME_LEN.to_string()),
+            "error should reference the limit: {}", msg);
     }
 }

--- a/src/services/recurring.rs
+++ b/src/services/recurring.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 use std::collections::HashSet;
 
-use crate::sql_queries;
+use crate::{sql_queries, consts};
 
 /// 周期と起点を一体で表現する。`unit` と「いつ発生するか」のアンカー情報を
 /// バリアントごとに固定することで、不正な組み合わせ（例: Day なのに DayOfMonth が
@@ -715,6 +715,38 @@ impl RecurringService {
             return Err(RecurringError::Validation(
                 "DETAIL.item_name must not be empty".to_string(),
             ));
+        }
+
+        // Bounded-field length checks (Issue #37 Phase 2-3, character count).
+        if let Some(rule_name) = &request.rule_name {
+            if rule_name.chars().count() > consts::MAX_RULE_NAME_LEN {
+                return Err(RecurringError::Validation(format!(
+                    "Rule name must be {} characters or less",
+                    consts::MAX_RULE_NAME_LEN
+                )));
+            }
+        }
+        if request.detail.item_name.chars().count() > consts::MAX_ITEM_NAME_LEN {
+            return Err(RecurringError::Validation(format!(
+                "Item name must be {} characters or less",
+                consts::MAX_ITEM_NAME_LEN
+            )));
+        }
+        if let Some(memo) = &request.header_memo {
+            if memo.chars().count() > consts::MAX_MEMO_LEN {
+                return Err(RecurringError::Validation(format!(
+                    "Header memo must be {} characters or less",
+                    consts::MAX_MEMO_LEN
+                )));
+            }
+        }
+        if let Some(memo) = &request.detail.detail_memo {
+            if memo.chars().count() > consts::MAX_MEMO_LEN {
+                return Err(RecurringError::Validation(format!(
+                    "Detail memo must be {} characters or less",
+                    consts::MAX_MEMO_LEN
+                )));
+            }
         }
 
         let anchor_date = match &request.anchor_date {
@@ -1742,5 +1774,101 @@ mod tests {
         assert_eq!(iso_to_weekday(7), Some(Weekday::Sun));
         assert_eq!(iso_to_weekday(0), None);
         assert_eq!(iso_to_weekday(8), None);
+    }
+
+    // Issue #37 Phase 2-3 — bounded-field length checks must count
+    // characters (not bytes). The validation runs before any DB I/O, so
+    // we exercise it against an empty in-memory pool.
+
+    fn minimal_request() -> SaveRecurringRuleRequest {
+        SaveRecurringRuleRequest {
+            rule_name: None,
+            period_unit: "DAY".to_string(),
+            period_interval: 1,
+            anchor_date: Some("2026-01-01".to_string()),
+            day_of_week: None,
+            month_day_rule_type: None,
+            day_of_month: None,
+            week_of_month: None,
+            month_of_year: None,
+            holiday_shift_type: 0,
+            start_date: "2026-01-01".to_string(),
+            end_date: "2026-01-01".to_string(),
+            shop_id: None,
+            category1_code: "EXPENSE".to_string(),
+            from_account_code: "BANK".to_string(),
+            to_account_code: "OUT".to_string(),
+            total_amount: 100,
+            tax_rounding_type: 0,
+            tax_included_type: 1,
+            header_memo: None,
+            detail: SaveRecurringRuleDetailRequest {
+                category1_code: "EXPENSE".to_string(),
+                category2_code: None,
+                category3_code: None,
+                item_name: "test".to_string(),
+                amount: 100,
+                tax_amount: 0,
+                tax_rate: 0,
+                amount_including_tax: Some(100),
+                detail_memo: None,
+            },
+        }
+    }
+
+    async fn empty_pool() -> SqlitePool {
+        SqlitePool::connect(":memory:").await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_create_rule_rejects_over_max_chars_of_multibyte_rule_name() {
+        let service = RecurringService::new(empty_pool().await);
+
+        let mut request = minimal_request();
+        request.rule_name = Some("あ".repeat(consts::MAX_RULE_NAME_LEN + 1));
+
+        let err = service.create_rule_with_instances(2, request).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(&consts::MAX_RULE_NAME_LEN.to_string()),
+            "error should reference the limit: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn test_create_rule_rejects_over_max_chars_of_multibyte_item_name() {
+        let service = RecurringService::new(empty_pool().await);
+
+        let mut request = minimal_request();
+        request.detail.item_name = "あ".repeat(consts::MAX_ITEM_NAME_LEN + 1);
+
+        let err = service.create_rule_with_instances(2, request).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(&consts::MAX_ITEM_NAME_LEN.to_string()),
+            "error should reference the limit: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn test_create_rule_rejects_over_max_chars_of_multibyte_header_memo() {
+        let service = RecurringService::new(empty_pool().await);
+
+        let mut request = minimal_request();
+        request.header_memo = Some("メ".repeat(consts::MAX_MEMO_LEN + 1));
+
+        let err = service.create_rule_with_instances(2, request).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(&consts::MAX_MEMO_LEN.to_string()),
+            "error should reference the limit: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn test_create_rule_rejects_over_max_chars_of_multibyte_detail_memo() {
+        let service = RecurringService::new(empty_pool().await);
+
+        let mut request = minimal_request();
+        request.detail.detail_memo = Some("メ".repeat(consts::MAX_MEMO_LEN + 1));
+
+        let err = service.create_rule_with_instances(2, request).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(&consts::MAX_MEMO_LEN.to_string()),
+            "error should reference the limit: {}", msg);
     }
 }

--- a/src/services/user_management.rs
+++ b/src/services/user_management.rs
@@ -1,7 +1,7 @@
 use sqlx::sqlite::SqlitePool;
 use sqlx::Row;
 use crate::security::{hash_password, verify_password, SecurityError};
-use crate::consts::{ROLE_ADMIN, ROLE_USER};
+use crate::consts::{self, ROLE_ADMIN, ROLE_USER};
 use crate::sql_queries;
 use super::encryption::EncryptionService;
 
@@ -22,6 +22,7 @@ pub enum UserManagementError {
     AdminUserCannotBeDeleted,
     InvalidRole,
     DuplicateUsername,
+    Validation(String),
 }
 
 impl std::fmt::Display for UserManagementError {
@@ -33,8 +34,21 @@ impl std::fmt::Display for UserManagementError {
             UserManagementError::AdminUserCannotBeDeleted => write!(f, "Admin user cannot be deleted"),
             UserManagementError::InvalidRole => write!(f, "Invalid role"),
             UserManagementError::DuplicateUsername => write!(f, "Username already exists"),
+            UserManagementError::Validation(msg) => write!(f, "{}", msg),
         }
     }
+}
+
+/// Issue #37 Phase 2-3 — USERS.NAME length guard. Counts characters, not
+/// bytes, mirroring the frontend `maxlength` and char counter.
+fn validate_username_length(username: &str) -> Result<(), UserManagementError> {
+    if username.chars().count() > consts::MAX_NAME_LEN {
+        return Err(UserManagementError::Validation(format!(
+            "Username must be {} characters or less",
+            consts::MAX_NAME_LEN
+        )));
+    }
+    Ok(())
 }
 
 impl std::error::Error for UserManagementError {}
@@ -106,8 +120,10 @@ impl UserManagementService {
         username: &str,
         password: &str,
     ) -> Result<i64, UserManagementError> {
+        validate_username_length(username)?;
+
         let now = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
-        
+
         let exists = sqlx::query(sql_queries::USER_CHECK_NAME_EXISTS)
             .bind(username)
             .fetch_one(&self.pool)
@@ -148,6 +164,10 @@ impl UserManagementService {
         new_password: Option<&str>,
         old_password: Option<&str>,
     ) -> Result<(), UserManagementError> {
+        if let Some(name) = new_username {
+            validate_username_length(name)?;
+        }
+
         let _user = self.get_user(user_id).await?;
         
         if let Some(password) = new_password {
@@ -606,12 +626,55 @@ mod tests {
     async fn test_list_users() {
         let pool = setup_test_db().await;
         create_test_admin(&pool, "admin", "admin_password123456").await;
-        
+
         let service = UserManagementService::new(pool.clone());
         service.register_general_user("user1", "password1").await.unwrap();
         service.register_general_user("user2", "password2").await.unwrap();
-        
+
         let users = service.list_users().await.unwrap();
         assert_eq!(users.len(), 3);
+    }
+
+    // Issue #37 Phase 2-3 — bounded-field length checks must count
+    // characters (not bytes). Japanese is 3 bytes per char in UTF-8.
+
+    #[tokio::test]
+    async fn test_register_general_user_accepts_max_chars_of_multibyte_name() {
+        let pool = setup_test_db().await;
+        create_test_admin(&pool, "admin", "admin_password123456").await;
+
+        let service = UserManagementService::new(pool.clone());
+        let name = "あ".repeat(consts::MAX_NAME_LEN);
+        let result = service.register_general_user(&name, "password123456").await;
+        assert!(result.is_ok(), "expected MAX_NAME_LEN multibyte chars to be accepted: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn test_register_general_user_rejects_over_max_chars_of_multibyte_name() {
+        let pool = setup_test_db().await;
+        create_test_admin(&pool, "admin", "admin_password123456").await;
+
+        let service = UserManagementService::new(pool.clone());
+        let name = "あ".repeat(consts::MAX_NAME_LEN + 1);
+        let err = service.register_general_user(&name, "password123456").await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(&consts::MAX_NAME_LEN.to_string()),
+            "error should reference the limit: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn test_update_general_user_rejects_over_max_chars_of_multibyte_name() {
+        let pool = setup_test_db().await;
+        create_test_admin(&pool, "admin", "admin_password123456").await;
+
+        let service = UserManagementService::new(pool.clone());
+        let user_id = service.register_general_user("testuser", "password123456")
+            .await.unwrap();
+
+        let name = "あ".repeat(consts::MAX_NAME_LEN + 1);
+        let err = service.update_general_user(user_id, Some(&name), None).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(&consts::MAX_NAME_LEN.to_string()),
+            "error should reference the limit: {}", msg);
     }
 }


### PR DESCRIPTION
## Summary

Phase 2-3 part 2 of Issue #37 — completes the inventory. After this PR every bounded text field in the matrix has the full 4-piece treatment: HTML `maxlength` + JS live counter + JS submit-time check + Rust `chars().count()` guard.

**Screens covered**:
- `transaction` (header + detail) — UI only (Rust was done in #44)
- `recurring` (予定入出金) — Rust + JS (HTML maxlength was already there)
- `category` (費目, multi-locale) — full 4 pieces
- `user_management` (ユーザマスタ) — full 4 pieces

## Per-screen detail

### transaction
- HTML: `maxlength="200"` on `#item-name`, `maxlength="1000"` on `#transaction-memo` and `#memo`.
- JS (header + detail): import validation-display helpers, attach `attachCharCounter`, dispatch `input` event in modal `onOpen` so counters refresh after `form.reset()` / programmatic value assignment, submit-time max check, map backend `"Item name must be"` / `"Memo must be"` errors to inline `validation.max_length` i18n.
- Header non-validation errors keep the original alert-only behavior (out of scope to change).

### recurring
- Rust: 4 new `chars().count()` guards inside `create_rule_with_instances` (rule_name, item_name, header_memo, detail_memo) before any DB I/O.
- JS: 4 counters attached at page init (the form is inline, not a modal). Reset button re-fires `input` to keep counters in sync. Submit-time max-length checks for all 4 fields. Backend error mapping for all 4.
- Tests: 4 new tokio tests using `SqlitePool::connect(":memory:")` — validation rejects before any SQL, so no schema setup needed.

### category (multi-locale)
- Rust: new `CategoryError::Validation(String)` variant + shared `validate_i18n_name_length(name, label)` helper that emits `"<label> must be N characters or less"` (label = `"Japanese name"` / `"English name"` for backend → frontend mapping). Wired into `add_category2` / `add_category3` / `update_category2_i18n` / `update_category3_i18n`. Uses `MAX_I18N_NAME_LEN` (256).
- HTML: `maxlength="256"` on all 6 i18n name inputs (cat1/2/3 × ja/en). cat1 has no Rust update path today but is wired for UX parity.
- JS: 6 counters attached in `initModals`. Cat2 / cat3 modals clear validation and re-fire `input` on open. Submit-time checks on both ja/en. Backend mapping for both lang variants.
- Tests: 6 new tokio tests against a full test DB (max-accept + 5 reject cases across cat2/cat3 add/update).

### user_management
- Rust: new `UserManagementError::Validation(String)` variant + `validate_username_length` helper using `MAX_NAME_LEN` (128). Applied in `register_general_user` and the central `update_user_internal` so all 5 update entry points get the guard for free.
- HTML: `maxlength="128"` on `#username`.
- JS: counter on username, modal `onOpen` refreshes, submit-time check, backend mapping.
- Tests: 3 new tokio tests (accept-max-multibyte, reject-over-max on register and update).

## Inventory status (Issue #37) — now complete

| Field | Rust | HTML | JS counter | JS submit | Backend err |
|---|---|---|---|---|---|
| USERS.NAME | ✅ this PR | ✅ this PR | ✅ this PR | ✅ this PR | ✅ this PR |
| CATEGORY*_I18N.*_NAME_I18N | ✅ this PR | ✅ this PR | ✅ this PR | ✅ this PR | ✅ this PR |
| ACCOUNTS.ACCOUNT_NAME | ✅ #47 | ✅ #47 | ✅ #47 | ✅ #47 | ✅ #47 |
| SHOPS.SHOP_NAME / MEMO | ✅ #46 | ✅ #46 | ✅ #46 | ✅ #46 | ✅ #46 |
| MANUFACTURERS.* | ✅ #47 | ✅ #47 | ✅ #47 | ✅ #47 | ✅ #47 |
| PRODUCTS.* | ✅ #47 | ✅ #47 | ✅ #47 | ✅ #47 | ✅ #47 |
| TRANSACTIONS_DETAIL.ITEM_NAME | ✅ #44 | ✅ this PR | ✅ this PR | ✅ this PR | ✅ this PR |
| TRANSACTIONS.MEMO | ✅ #44 | ✅ this PR | ✅ this PR | ✅ this PR | ✅ this PR |
| RECURRING_RULES.RULE_NAME | ✅ this PR | ✅ v2.1.0 | ✅ this PR | ✅ this PR | ✅ this PR |
| RECURRING_*.ITEM_NAME | ✅ this PR | ✅ v2.1.0 | ✅ this PR | ✅ this PR | ✅ this PR |
| RECURRING_*.MEMO | ✅ this PR | ✅ v2.1.0 | ✅ this PR | ✅ this PR | ✅ this PR |

CATEGORY1/2/3.*_NAME (non-i18n VARCHAR(128)) columns hold pinyin-style internal codes that are never user-edited — left as schema documentation.

## Test plan

- [x] `cargo test --lib` — **350 passed** (was 337 after #47; +13 new tests: 4 recurring + 6 category + 3 user_management)
- [x] `cd res/tests && npm test` — **609 passed**, 4 skipped
- [x] `node --check` on all 5 modified JS files
- [x] `cargo build --tests` — clean (pre-existing dead_code warnings on `weekday_to_iso` only)
- [ ] Manual smoke: open each of the 5 management screens, type 128/200/256/1000 (matching the field's limit) of Japanese chars → counter goes red at the boundary, HTML blocks at limit, submit-time / Rust messages fire when limit is bypassed via paste.

## Notes

- No new i18n keys added. All field labels (`detail_mgmt.item_name`, `transaction_mgmt.memo`, `recurring_rule.rule_name`/`header_memo`/`item_name`/`detail_memo`, `category_mgmt.name_ja`/`name_en`, `user_mgmt.username`) already exist in `dbaccess.sql`.
- The `MAX_RULE_NAME_LEN` and `MAX_I18N_NAME_LEN` constants in `src/consts.rs` previously carried `#[allow(dead_code)]` — those attributes are no longer needed once recurring/category use them, but they're left in place to avoid churn; rustc no longer warns since the consts are now read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)