### PR TITLE
feat(ui): add toast/notification component (#45)

### DIFF
--- a/res/js/toast.js
+++ b/res/js/toast.js
@@ -1,0 +1,196 @@
+/**
+ * Shared transient-notification helper (toast).
+ *
+ * Renders short-lived messages in a fixed-position container at the
+ * bottom-right of the viewport. Designed to replace scattered
+ * `alert()` calls and surface success / error / warning / info feedback
+ * without blocking the user.
+ *
+ * Issue #45 — independent from but parallel to `validation-display.js`:
+ *   - validation-display: inline, persistent until cleared (next to field)
+ *   - toast: transient, auto-dismissing, viewport-anchored
+ *
+ * Self-mounting: the container DOM and styles are injected on first
+ * call. Callers only need `import { showToast } from './toast.js'`.
+ *
+ * i18n contract: callers pass already-translated text, same as
+ * `validation-display.js`. This module does not call `i18n.t`.
+ */
+
+const CONTAINER_ID = 'kb-toast-container';
+const STYLE_ID = 'kb-toast-style';
+const TOAST_CLASS = 'kb-toast';
+const VARIANTS = new Set(['info', 'success', 'warning', 'error']);
+const DEFAULT_DURATION_MS = 3000;
+const ENTER_TRANSITION_MS = 200;
+const EXIT_TRANSITION_MS = 200;
+
+const STYLE_CSS = `
+#${CONTAINER_ID} {
+    position: fixed;
+    bottom: 16px;
+    right: 16px;
+    display: flex;
+    flex-direction: column-reverse;
+    gap: 8px;
+    z-index: 9999;
+    pointer-events: none;
+    max-width: calc(100vw - 32px);
+}
+.${TOAST_CLASS} {
+    pointer-events: auto;
+    min-width: 240px;
+    max-width: 420px;
+    padding: 12px 16px;
+    border-radius: 6px;
+    color: #fff;
+    background: #3498db;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    font-size: 14px;
+    line-height: 1.4;
+    opacity: 0;
+    transform: translateX(20px);
+    transition: opacity ${ENTER_TRANSITION_MS}ms ease-out, transform ${ENTER_TRANSITION_MS}ms ease-out;
+}
+.${TOAST_CLASS}.show {
+    opacity: 1;
+    transform: translateX(0);
+}
+.${TOAST_CLASS}.hide {
+    opacity: 0;
+    transform: translateX(20px);
+    transition: opacity ${EXIT_TRANSITION_MS}ms ease-in, transform ${EXIT_TRANSITION_MS}ms ease-in;
+}
+.${TOAST_CLASS}-info { background: #3498db; }
+.${TOAST_CLASS}-success { background: #27ae60; }
+.${TOAST_CLASS}-warning { background: #d68910; }
+.${TOAST_CLASS}-error { background: #c0392b; }
+.${TOAST_CLASS}-text {
+    flex: 1;
+    word-break: break-word;
+    white-space: pre-line;
+}
+.${TOAST_CLASS}-close {
+    background: transparent;
+    border: 0;
+    color: inherit;
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 4px;
+    opacity: 0.85;
+}
+.${TOAST_CLASS}-close:hover {
+    opacity: 1;
+}
+`;
+
+function ensureMounted() {
+    if (typeof document === 'undefined') return null;
+    if (!document.getElementById(STYLE_ID)) {
+        const style = document.createElement('style');
+        style.id = STYLE_ID;
+        style.textContent = STYLE_CSS;
+        document.head.appendChild(style);
+    }
+    let container = document.getElementById(CONTAINER_ID);
+    if (!container) {
+        container = document.createElement('div');
+        container.id = CONTAINER_ID;
+        container.setAttribute('aria-live', 'polite');
+        document.body.appendChild(container);
+    }
+    return container;
+}
+
+/**
+ * Show a transient toast notification.
+ *
+ * @param {string} message - already-translated, ready-to-display text
+ * @param {object} [options]
+ * @param {'info'|'success'|'warning'|'error'} [options.variant='info']
+ * @param {number} [options.duration=3000] - auto-dismiss delay in ms; pass 0 to disable auto-dismiss
+ * @returns {() => void} dismiss — call to remove the toast programmatically (no-op if already gone)
+ */
+export function showToast(message, options = {}) {
+    const container = ensureMounted();
+    if (!container) return () => {};
+
+    const variant = VARIANTS.has(options.variant) ? options.variant : 'info';
+    const duration = Number.isFinite(options.duration) ? options.duration : DEFAULT_DURATION_MS;
+
+    const toast = document.createElement('div');
+    toast.className = `${TOAST_CLASS} ${TOAST_CLASS}-${variant}`;
+    // Errors interrupt screen readers; the rest defer to the next idle moment.
+    toast.setAttribute('role', variant === 'error' ? 'alert' : 'status');
+    toast.setAttribute('aria-live', variant === 'error' ? 'assertive' : 'polite');
+
+    const text = document.createElement('span');
+    text.className = `${TOAST_CLASS}-text`;
+    text.textContent = String(message ?? '');
+    toast.appendChild(text);
+
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = `${TOAST_CLASS}-close`;
+    closeBtn.setAttribute('aria-label', 'Dismiss');
+    closeBtn.textContent = '×';
+    toast.appendChild(closeBtn);
+
+    container.appendChild(toast);
+
+    // Defer adding `show` to the next frame so the browser observes the
+    // initial (hidden) state and animates into the visible one.
+    const raf = (typeof requestAnimationFrame === 'function')
+        ? requestAnimationFrame
+        : (cb) => setTimeout(cb, 16);
+    raf(() => toast.classList.add('show'));
+
+    let exitTimer = null;
+    let removeTimer = null;
+    let dismissed = false;
+
+    const dismiss = () => {
+        if (dismissed) return;
+        dismissed = true;
+        if (exitTimer) clearTimeout(exitTimer);
+        exitTimer = null;
+        toast.classList.remove('show');
+        toast.classList.add('hide');
+        // Fallback removal in case `transitionend` never fires (e.g. jsdom).
+        removeTimer = setTimeout(() => {
+            if (toast.parentNode) toast.parentNode.removeChild(toast);
+        }, EXIT_TRANSITION_MS + 50);
+        toast.addEventListener('transitionend', () => {
+            if (removeTimer) clearTimeout(removeTimer);
+            if (toast.parentNode) toast.parentNode.removeChild(toast);
+        }, { once: true });
+    };
+
+    closeBtn.addEventListener('click', dismiss);
+
+    if (duration > 0) {
+        exitTimer = setTimeout(dismiss, duration);
+    }
+
+    return dismiss;
+}
+
+/**
+ * Remove all currently-mounted toasts and the container. Mostly useful
+ * for tests; production code should let toasts auto-dismiss.
+ */
+export function clearAllToasts() {
+    if (typeof document === 'undefined') return;
+    const container = document.getElementById(CONTAINER_ID);
+    if (container && container.parentNode) {
+        container.parentNode.removeChild(container);
+    }
+    const style = document.getElementById(STYLE_ID);
+    if (style && style.parentNode) {
+        style.parentNode.removeChild(style);
+    }
+}

--- a/res/tests/toast.test.js
+++ b/res/tests/toast.test.js
@@ -1,0 +1,161 @@
+import { jest } from '@jest/globals';
+import { showToast, clearAllToasts } from '../js/toast.js';
+
+// Toast module is self-mounting (injects its own <style> and container on
+// first call). Each test starts from a clean DOM so we observe the
+// mount-on-first-call behavior independently.
+
+const CONTAINER_ID = 'kb-toast-container';
+const STYLE_ID = 'kb-toast-style';
+const TOAST_CLASS = 'kb-toast';
+
+function getContainer() {
+    return document.getElementById(CONTAINER_ID);
+}
+
+function getToasts() {
+    const container = getContainer();
+    return container ? Array.from(container.querySelectorAll(`.${TOAST_CLASS}`)) : [];
+}
+
+beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.innerHTML = '';
+    document.head.innerHTML = '';
+});
+
+afterEach(() => {
+    clearAllToasts();
+    jest.useRealTimers();
+});
+
+describe('showToast — mounting', () => {
+    test('injects style and container on first call', () => {
+        expect(document.getElementById(STYLE_ID)).toBeNull();
+        expect(getContainer()).toBeNull();
+
+        showToast('hello');
+
+        expect(document.getElementById(STYLE_ID)).not.toBeNull();
+        expect(getContainer()).not.toBeNull();
+    });
+
+    test('reuses the same container across multiple calls', () => {
+        showToast('first');
+        const containerAfterFirst = getContainer();
+        showToast('second');
+        const containerAfterSecond = getContainer();
+
+        expect(containerAfterFirst).toBe(containerAfterSecond);
+        expect(document.querySelectorAll(`#${CONTAINER_ID}`).length).toBe(1);
+        expect(document.querySelectorAll(`#${STYLE_ID}`).length).toBe(1);
+    });
+});
+
+describe('showToast — rendering', () => {
+    test('renders the message text verbatim (caller is responsible for i18n)', () => {
+        showToast('保存しました');
+        const toasts = getToasts();
+        expect(toasts).toHaveLength(1);
+        expect(toasts[0].querySelector(`.${TOAST_CLASS}-text`).textContent).toBe('保存しました');
+    });
+
+    test('defaults to the info variant when none is given', () => {
+        showToast('hi');
+        const toast = getToasts()[0];
+        expect(toast.classList.contains(`${TOAST_CLASS}-info`)).toBe(true);
+    });
+
+    test('applies the requested variant class', () => {
+        for (const variant of ['info', 'success', 'warning', 'error']) {
+            clearAllToasts();
+            showToast('msg', { variant });
+            const toast = getToasts()[0];
+            expect(toast.classList.contains(`${TOAST_CLASS}-${variant}`)).toBe(true);
+        }
+    });
+
+    test('falls back to info for an unknown variant rather than rendering nothing', () => {
+        showToast('msg', { variant: 'bogus' });
+        const toast = getToasts()[0];
+        expect(toast.classList.contains(`${TOAST_CLASS}-info`)).toBe(true);
+    });
+
+    test('error variant uses role=alert and aria-live=assertive for screen readers', () => {
+        showToast('boom', { variant: 'error' });
+        const toast = getToasts()[0];
+        expect(toast.getAttribute('role')).toBe('alert');
+        expect(toast.getAttribute('aria-live')).toBe('assertive');
+    });
+
+    test('non-error variants use role=status / aria-live=polite', () => {
+        showToast('ok', { variant: 'success' });
+        const toast = getToasts()[0];
+        expect(toast.getAttribute('role')).toBe('status');
+        expect(toast.getAttribute('aria-live')).toBe('polite');
+    });
+});
+
+describe('showToast — dismissal', () => {
+    test('auto-dismisses after the configured duration', () => {
+        showToast('bye', { duration: 1000 });
+        expect(getToasts()).toHaveLength(1);
+
+        // Trigger the auto-dismiss timer and the fallback removal timer.
+        jest.advanceTimersByTime(1000);
+        jest.advanceTimersByTime(500);
+
+        expect(getToasts()).toHaveLength(0);
+    });
+
+    test('duration=0 keeps the toast visible (no auto-dismiss timer fires)', () => {
+        showToast('sticky', { duration: 0 });
+        jest.advanceTimersByTime(10000);
+        expect(getToasts()).toHaveLength(1);
+    });
+
+    test('returned dismiss function removes the toast immediately', () => {
+        const dismiss = showToast('manual', { duration: 0 });
+        expect(getToasts()).toHaveLength(1);
+
+        dismiss();
+        // Drain the fallback removal timer.
+        jest.advanceTimersByTime(500);
+        expect(getToasts()).toHaveLength(0);
+    });
+
+    test('clicking the close button dismisses the toast', () => {
+        showToast('closable', { duration: 0 });
+        const toast = getToasts()[0];
+        const closeBtn = toast.querySelector(`.${TOAST_CLASS}-close`);
+        expect(closeBtn).not.toBeNull();
+
+        closeBtn.click();
+        jest.advanceTimersByTime(500);
+        expect(getToasts()).toHaveLength(0);
+    });
+
+    test('dismiss is idempotent — calling it twice does not throw', () => {
+        const dismiss = showToast('once', { duration: 0 });
+        dismiss();
+        expect(() => dismiss()).not.toThrow();
+        jest.advanceTimersByTime(500);
+        expect(getToasts()).toHaveLength(0);
+    });
+});
+
+describe('showToast — stacking', () => {
+    test('multiple toasts stack inside the same container', () => {
+        showToast('first', { duration: 0 });
+        showToast('second', { duration: 0 });
+        showToast('third', { duration: 0 });
+
+        const toasts = getToasts();
+        expect(toasts).toHaveLength(3);
+        // Insertion order is preserved at the DOM level; the visual
+        // bottom-up stacking is handled by `flex-direction: column-reverse`
+        // in the CSS, which we don't assert in jsdom.
+        expect(toasts[0].textContent).toContain('first');
+        expect(toasts[2].textContent).toContain('third');
+    });
+});


### PR DESCRIPTION
Closes part of #45 — adds the core component. Adoption (replacing `alert()` calls, wiring success feedback) follows in per-screen PRs as the issue specifies.

## Summary

- New `res/js/toast.js` — shared transient-notification helper, parallel to `validation-display.js`.
- `showToast(message, { variant, duration })` returns a dismiss handle.
- Variants: `info` / `success` / `warning` / `error`. Errors use `role=alert` + `aria-live=assertive`; others use `role=status` + `aria-live=polite`.
- Self-mounting: container DOM and `<style>` are injected on first call. **No HTML changes required** — pages import the module and call it.
- Auto-dismiss (default 3000 ms, `duration: 0` disables), manual dismiss via the close button or the returned handle. Idempotent.
- 14 new Jest tests in `res/tests/toast.test.js` cover mounting, rendering, variant fallbacks, ARIA, auto/manual dismissal, idempotency, and stacking.

## Out of scope (per Issue #45 "Integration points (deferred)")

- Replacing existing `alert()` calls across management screens.
- Surfacing success toasts on save/delete flows.
- Wiring `validation-display.js` to also fire a toast (#37 follow-up).

These will land as per-screen PRs.

## Test plan

- [x] `cd res/tests && npm test` — 16 suites, 623 passed, no regressions
- [x] `cd res/tests && npm test -- --testPathPattern=toast.test.js` — 14/14 pass
- [ ] Manual visual check in `cargo tauri dev` (CSS rendering, animation, stacking) — to be done post-merge or before the first integration PR

## i18n

Caller passes already-localized text (same contract as `validation-display.js`). No new i18n keys in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)