### PR TITLE
feat(ui): replace alert() with toast in shop / manufacturer / product (#50)

### DIFF
--- a/res/js/manufacturer-management.js
+++ b/res/js/manufacturer-management.js
@@ -7,6 +7,7 @@ import { setupIndicators } from './indicators.js';
 import { getCurrentSessionUser, isSessionAuthenticated } from './session.js';
 import { createMenuBar } from './menu.js';
 import { showValidationError, clearValidationError, showMaxLengthError, attachCharCounter } from './validation-display.js';
+import { showToast } from './toast.js';
 import { MAX_NAME_LEN, MAX_MEMO_LEN } from './consts.js';
 
 console.log('=== MANUFACTURER-MANAGEMENT.JS LOADED ===');
@@ -75,7 +76,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         await adjustWindowSize();
     } catch (error) {
         console.error('Initialization error:', error);
-        alert(i18n.t('manufacturer_mgmt.failed_to_initialize') + ': ' + error);
+        showToast(i18n.t('manufacturer_mgmt.failed_to_initialize') + ': ' + error, { variant: 'error' });
     }
 });
 
@@ -397,7 +398,7 @@ async function deleteManufacturer(manufacturerId) {
         await loadManufacturers();
     } catch (error) {
         console.error('Failed to delete manufacturer:', error);
-        alert(i18n.t('manufacturer_mgmt.failed_to_delete') + ': ' + error);
+        showToast(i18n.t('manufacturer_mgmt.failed_to_delete') + ': ' + error, { variant: 'error' });
     }
 }
 

--- a/res/js/product-management.js
+++ b/res/js/product-management.js
@@ -7,6 +7,7 @@ import { setupIndicators } from './indicators.js';
 import { getCurrentSessionUser, isSessionAuthenticated } from './session.js';
 import { createMenuBar } from './menu.js';
 import { showValidationError, clearValidationError, showMaxLengthError, attachCharCounter } from './validation-display.js';
+import { showToast } from './toast.js';
 import { MAX_NAME_LEN, MAX_MEMO_LEN } from './consts.js';
 
 console.log('=== PRODUCT-MANAGEMENT.JS LOADED ===');
@@ -77,7 +78,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         await adjustWindowSize();
     } catch (error) {
         console.error('Initialization error:', error);
-        alert(i18n.t('product_mgmt.failed_to_initialize') + ': ' + error);
+        showToast(i18n.t('product_mgmt.failed_to_initialize') + ': ' + error, { variant: 'error' });
     }
 });
 
@@ -448,7 +449,7 @@ async function deleteProduct(productId) {
         await loadProducts();
     } catch (error) {
         console.error('Failed to delete product:', error);
-        alert(i18n.t('product_mgmt.failed_to_delete') + ': ' + error);
+        showToast(i18n.t('product_mgmt.failed_to_delete') + ': ' + error, { variant: 'error' });
     }
 }
 

--- a/res/js/shop-management.js
+++ b/res/js/shop-management.js
@@ -7,6 +7,7 @@ import { setupIndicators } from './indicators.js';
 import { getCurrentSessionUser, isSessionAuthenticated, getSessionSourceScreen, clearSessionSourceScreen } from './session.js';
 import { createMenuBar } from './menu.js';
 import { showValidationError, clearValidationError, showMaxLengthError, attachCharCounter } from './validation-display.js';
+import { showToast } from './toast.js';
 import { MAX_NAME_LEN, MAX_MEMO_LEN } from './consts.js';
 
 console.log('=== SHOP-MANAGEMENT.JS LOADED ===');
@@ -74,7 +75,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         await adjustWindowSize();
     } catch (error) {
         console.error('Initialization error:', error);
-        alert(i18n.t('shop_mgmt.failed_to_initialize') + ': ' + error);
+        showToast(i18n.t('shop_mgmt.failed_to_initialize') + ': ' + error, { variant: 'error' });
     }
 });
 
@@ -362,7 +363,7 @@ async function deleteShop(shopId) {
         await loadShops();
     } catch (error) {
         console.error('Failed to delete shop:', error);
-        alert(i18n.t('shop_mgmt.failed_to_delete') + ': ' + error);
+        showToast(i18n.t('shop_mgmt.failed_to_delete') + ': ' + error, { variant: 'error' });
     }
 }
 


### PR DESCRIPTION
Second sub-PR for #50. Three management screens with identical structure are migrated together.

## Files in this PR

- [x] `res/js/shop-management.js` — failed_to_initialize + failed_to_delete → `showToast(..., { variant: 'error' })`
- [x] `res/js/manufacturer-management.js` — same two sites
- [x] `res/js/product-management.js` — same two sites

6 `alert()` calls removed in total. All sites pass the navigation-bound check from the [rule in #50](https://github.com/BonoJovi/KakeiBonByRust/issues/50#issuecomment-4467092147):

- `failed_to_initialize` — fires in DOMContentLoaded's catch with no follow-up navigation; the screen stays put (partial render).
- `failed_to_delete` — fires after `invoke('delete_*')` rejects; the screen stays put.

The early-return `window.location.href = INDEX` guards (session/user-missing) in these files are alert-free already and not affected.

## Out of scope (intentional)

- No new success toasts: the success paths already work — list reloads visibly after add/update/delete, so the screen state itself is the feedback. Adding success toasts would be a separate UX decision per screen.
- No new i18n keys.

## Test plan

- [x] `cd res/tests && npm test` — 16 suites, 623 passed, no regressions

**Note on manual smoke:** both `failed_to_initialize` and `failed_to_delete` paths are practically unreachable under normal use (init never errors out, and delete rejections are blocked by the Rust-side referential integrity / UI flow before reaching this catch). Same pattern as the language / font-size errors in PR #51. The change is a 1:1 `alert()` → `showToast()` swap with no logic difference, so regression risk is minimal.

## Progress on #50

- [x] dashboard / transaction-detail / menu / font-size (PR #51)
- [x] shop / manufacturer / product (this PR)
- [ ] account-management
- [ ] transaction-management
- [ ] category-management

🤖 Generated with [Claude Code](https://claude.com/claude-code)
