### PR TITLE
fix: management page degradations (delete modal + aggregation submenus)

### DIFF
--- a/res/js/aggregation-daily.js
+++ b/res/js/aggregation-daily.js
@@ -3,7 +3,7 @@ import i18n from './i18n.js';
 import { setupIndicators } from './indicators.js';
 import { setupFontSizeMenuHandlers, setupFontSizeMenu, applyFontSize, setupFontSizeModalHandlers} from './font-size.js';
 import { fitWindowToScreen } from './window-fit.js';
-import { setupLanguageMenuHandlers, setupLanguageMenu } from './menu.js';
+import { setupLanguageMenuHandlers, setupLanguageMenu, setupFileMenuHandlers } from './menu.js';
 import { HTML_FILES } from './html-files.js';
 import { getCurrentSessionUser, isSessionAuthenticated } from './session.js';
 import { createMenuBar } from './menu.js';
@@ -107,23 +107,7 @@ function setupEventHandlers() {
 }
 
 function setupMenuHandlers() {
-    // File menu handlers
-    const fileMenu = document.getElementById('file-menu');
-    const fileDropdown = document.getElementById('file-dropdown');
-    
-    if (fileMenu && fileDropdown) {
-        fileMenu.addEventListener('click', (e) => {
-            e.stopPropagation();
-            fileDropdown.classList.toggle('show');
-        });
-        
-        // Close dropdowns when clicking outside
-        document.addEventListener('click', () => {
-            document.querySelectorAll('.dropdown').forEach(dropdown => {
-                dropdown.classList.remove('show');
-            });
-        });
-    }
+    setupFileMenuHandlers();
 }
 
 async function executeAggregation() {

--- a/res/js/aggregation-period.js
+++ b/res/js/aggregation-period.js
@@ -3,7 +3,7 @@ import i18n from './i18n.js';
 import { setupIndicators } from './indicators.js';
 import { setupFontSizeMenuHandlers, setupFontSizeMenu, applyFontSize, setupFontSizeModalHandlers} from './font-size.js';
 import { fitWindowToScreen } from './window-fit.js';
-import { setupLanguageMenuHandlers, setupLanguageMenu } from './menu.js';
+import { setupLanguageMenuHandlers, setupLanguageMenu, setupFileMenuHandlers } from './menu.js';
 import { HTML_FILES } from './html-files.js';
 import { getCurrentSessionUser, isSessionAuthenticated } from './session.js';
 import { createMenuBar } from './menu.js';
@@ -96,21 +96,7 @@ function setupEventHandlers() {
 }
 
 function setupMenuHandlers() {
-    const fileMenu = document.getElementById('file-menu');
-    const fileDropdown = document.getElementById('file-dropdown');
-    
-    if (fileMenu && fileDropdown) {
-        fileMenu.addEventListener('click', (e) => {
-            e.stopPropagation();
-            fileDropdown.classList.toggle('show');
-        });
-        
-        document.addEventListener('click', () => {
-            document.querySelectorAll('.dropdown').forEach(dropdown => {
-                dropdown.classList.remove('show');
-            });
-        });
-    }
+    setupFileMenuHandlers();
 }
 
 async function executeAggregation() {

--- a/res/js/aggregation-weekly.js
+++ b/res/js/aggregation-weekly.js
@@ -3,7 +3,7 @@ import i18n from './i18n.js';
 import { setupIndicators } from './indicators.js';
 import { setupFontSizeMenuHandlers, setupFontSizeMenu, applyFontSize, setupFontSizeModalHandlers} from './font-size.js';
 import { fitWindowToScreen } from './window-fit.js';
-import { setupLanguageMenuHandlers, setupLanguageMenu } from './menu.js';
+import { setupLanguageMenuHandlers, setupLanguageMenu, setupFileMenuHandlers } from './menu.js';
 import { HTML_FILES } from './html-files.js';
 import { getCurrentSessionUser, isSessionAuthenticated } from './session.js';
 import { createMenuBar } from './menu.js';
@@ -142,21 +142,7 @@ function updateWeekRangeDisplay() {
 }
 
 function setupMenuHandlers() {
-    const fileMenu = document.getElementById('file-menu');
-    const fileDropdown = document.getElementById('file-dropdown');
-    
-    if (fileMenu && fileDropdown) {
-        fileMenu.addEventListener('click', (e) => {
-            e.stopPropagation();
-            fileDropdown.classList.toggle('show');
-        });
-        
-        document.addEventListener('click', () => {
-            document.querySelectorAll('.dropdown').forEach(dropdown => {
-                dropdown.classList.remove('show');
-            });
-        });
-    }
+    setupFileMenuHandlers();
 }
 
 async function executeAggregation() {

--- a/res/js/aggregation-yearly.js
+++ b/res/js/aggregation-yearly.js
@@ -3,7 +3,7 @@ import i18n from './i18n.js';
 import { setupIndicators } from './indicators.js';
 import { setupFontSizeMenuHandlers, setupFontSizeMenu, applyFontSize, setupFontSizeModalHandlers} from './font-size.js';
 import { fitWindowToScreen } from './window-fit.js';
-import { setupLanguageMenuHandlers, setupLanguageMenu } from './menu.js';
+import { setupLanguageMenuHandlers, setupLanguageMenu, setupFileMenuHandlers } from './menu.js';
 import { HTML_FILES } from './html-files.js';
 import { getCurrentSessionUser, isSessionAuthenticated } from './session.js';
 import { createMenuBar } from './menu.js';
@@ -101,21 +101,7 @@ function setupEventHandlers() {
 }
 
 function setupMenuHandlers() {
-    const fileMenu = document.getElementById('file-menu');
-    const fileDropdown = document.getElementById('file-dropdown');
-    
-    if (fileMenu && fileDropdown) {
-        fileMenu.addEventListener('click', (e) => {
-            e.stopPropagation();
-            fileDropdown.classList.toggle('show');
-        });
-        
-        document.addEventListener('click', () => {
-            document.querySelectorAll('.dropdown').forEach(dropdown => {
-                dropdown.classList.remove('show');
-            });
-        });
-    }
+    setupFileMenuHandlers();
 }
 
 async function executeAggregation() {

--- a/res/js/aggregation.js
+++ b/res/js/aggregation.js
@@ -4,7 +4,7 @@ import { setupFontSizeMenuHandlers, setupFontSizeMenu, applyFontSize, setupFontS
 import { fitWindowToScreen } from './window-fit.js';
 import { HTML_FILES } from './html-files.js';
 import { getCurrentSessionUser, isSessionAuthenticated } from './session.js';
-import { createMenuBar } from './menu.js';
+import { createMenuBar, setupFileMenuHandlers } from './menu.js';
 import * as AggCommon from './aggregation-common.js';
 
 console.log('aggregation.js loaded');
@@ -284,12 +284,7 @@ function clearMessage() {
 
 // Menu handlers (copied from other management pages)
 function setupMenuHandlers() {
-    // Close all dropdowns when clicking outside
-    document.addEventListener('click', (e) => {
-        if (!e.target.closest('.menu-item')) {
-            closeAllDropdowns();
-        }
-    });
+    setupFileMenuHandlers();
 }
 
 function closeAllDropdowns() {

--- a/res/js/menu.js
+++ b/res/js/menu.js
@@ -788,6 +788,75 @@ function setupCustomValidationMessages() {
     });
 }
 
+/**
+ * Wire up the "File" menu for management-style pages (dashboard, aggregation, *-management).
+ *
+ * Handles three submenu items in the dropdown injected by `createMenuBar('management')`:
+ *   - "Back to Main" → navigate to INDEX
+ *   - "Logout"       → clear session, navigate to INDEX
+ *   - "Quit"         → invoke `handle_quit`
+ *
+ * Pages used to duplicate this wiring inline; aggregation pages were missing the
+ * submenu listeners entirely, so submenu clicks were silently dropped (v2.4.0 fix).
+ * Submenu items are resolved by `data-i18n` key so DOM order changes don't break wiring.
+ */
+export function setupFileMenuHandlers() {
+    const fileMenu = document.getElementById('file-menu');
+    const fileDropdown = document.getElementById('file-dropdown');
+    if (!fileMenu || !fileDropdown) {
+        console.warn('[setupFileMenuHandlers] file-menu or file-dropdown not found');
+        return;
+    }
+
+    fileMenu.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const isShown = fileDropdown.classList.contains('show');
+        document.querySelectorAll('.dropdown').forEach((d) => {
+            if (d !== fileDropdown) d.classList.remove('show');
+        });
+        fileDropdown.classList.toggle('show', !isShown);
+    });
+
+    fileDropdown.addEventListener('click', (e) => e.stopPropagation());
+
+    const backToMainItem = fileDropdown.querySelector('[data-i18n="menu.back_to_main"]');
+    const logoutItem = fileDropdown.querySelector('[data-i18n="menu.logout"]');
+    const quitItem = fileDropdown.querySelector('[data-i18n="menu.quit"]');
+
+    if (backToMainItem) {
+        backToMainItem.addEventListener('click', (e) => {
+            e.stopPropagation();
+            window.location.href = HTML_FILES.INDEX;
+        });
+    }
+
+    if (logoutItem) {
+        logoutItem.addEventListener('click', async (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            fileDropdown.classList.remove('show');
+            try {
+                await session.clearSession();
+                window.location.href = HTML_FILES.INDEX;
+            } catch (error) {
+                console.error('Logout failed:', error);
+            }
+        });
+    }
+
+    if (quitItem) {
+        quitItem.addEventListener('click', async (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            try {
+                await invoke('handle_quit');
+            } catch (error) {
+                console.error('Quit failed:', error);
+            }
+        });
+    }
+}
+
 // Export functions for use in other modules
 export {
     setupLanguageMenuHandlers,

--- a/res/js/modal.js
+++ b/res/js/modal.js
@@ -255,25 +255,23 @@ class Modal {
      * @private
      */
     async _handleSave() {
-        if (!this.form) {
-            console.warn('No form associated with this modal');
-            return;
-        }
-        
-        // Collect form data
-        const formData = new FormData(this.form);
-        const data = Object.fromEntries(formData.entries());
+        // Collect form data when a form is associated. Confirmation-style
+        // modals (e.g. delete confirm) have no form — they rely on `this.data`
+        // populated by `open(mode, data)`.
+        const data = this.form
+            ? Object.fromEntries(new FormData(this.form).entries())
+            : {};
 
         // Add mode and stored data
         data.mode = this.mode;
         if (this.data) {
             Object.assign(data, this.data);
         }
-        
+
         try {
             // Call onSave callback
             await this.options.onSave(data);
-            
+
             // Close modal on success
             this.close();
         } catch (error) {

--- a/res/js/user-management.js
+++ b/res/js/user-management.js
@@ -10,6 +10,7 @@ import { createMenuBar } from './menu.js';
 import { showValidationError, clearValidationError, showMaxLengthError, attachCharCounter } from './validation-display.js';
 import { invalidatePeriodSettingsCache } from './period.js';
 import { fitWindowToScreen } from './window-fit.js';
+import { showToast } from './toast.js';
 
 let currentUsers = [];
 let editingUserId = null;
@@ -580,17 +581,14 @@ function closeDeleteModal() {
 
 async function handleUserDelete(userId) {
     if (!userId) return;
-    
-    showMessage('delete-result-message', i18n.t('user_mgmt.deleting'), 'info');
-    
-    await invoke('delete_general_user_info', { userId: userId });
-    
-    showMessage('delete-result-message', i18n.t('user_mgmt.user_deleted'), 'success');
-    
-    setTimeout(async () => {
-        deleteModal.close();
+    try {
+        await invoke('delete_general_user_info', { userId: userId });
+        showToast(i18n.t('user_mgmt.user_deleted'), { variant: 'success' });
         await loadUsers();
-    }, 1500);
+    } catch (error) {
+        showToast(i18n.t('error.delete_user_failed') + ': ' + error, { variant: 'error' });
+        throw error;
+    }
 }
 
 function handleLogout() {


### PR DESCRIPTION
## Summary

Two long-standing degradations on management-style pages:

1. **Delete confirmation modal never fired its action.** The Modal class assumed every modal had an associated `<form>` and silently dropped save clicks when none was wired. User-management's delete-modal is form-less, so the **Delete** button did nothing.
2. **Aggregation pages' File submenu items were dead.** The five aggregation pages (monthly / yearly / weekly / daily / period) only toggled the File dropdown; the three submenu items (Back to Main / Logout / Quit) had no click handlers attached.

Dashboard and `*-management` pages didn't regress because they wired the submenu handlers inline. The regression was confined to the aggregation page family + the form-less confirmation modal pattern.

## What changed

### 3a665232 — modal + delete flow

- `Modal._handleSave` now falls back to `{}` when no form is wired and still merges `mode` + stored `data`, so confirmation modals reach `onSave(data)`.
- `handleUserDelete` migrated off `setTimeout(loadUsers, 1500)` (deleted row would linger for 1.5 s after the modal closed) to `showToast` + immediate `loadUsers()`. Errors surface via toast and rethrow so the modal stays open on failure.

### ecf7b297 — aggregation submenu wiring

- New shared `setupFileMenuHandlers` in `menu.js` extracted from the working dashboard implementation. Submenu items resolved by `data-i18n` key so DOM order in `createMenuBar` doesn't break wiring.
- Each aggregation page's `setupMenuHandlers` now delegates to this helper, replacing the inline File-menu toggle that lacked submenu listeners.
- Dashboard + `*-management` pages keep their inline implementations to limit blast radius; migrating them to the shared helper is a separate cleanup PR.

## Test plan

- [x] Delete-modal: confirm-delete now triggers `handleUserDelete`, toast appears, list updates immediately
- [x] Aggregation pages × 5 (monthly / yearly / weekly / daily / period): File menu submenu items respond:
  - Back to Main → navigates to INDEX
  - Logout → clears session, navigates to INDEX
  - Quit → invokes `handle_quit`
- [x] Dashboard menu unchanged (smoke checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)