### PR TITLE
fix(db): embed schema/seed SQL at compile time — v2.4.1 hotfix for Windows startup crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "2.4.0"
+version = "2.4.1"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kakeibonbyrust",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Household Budget App \"KakeiBon\" built with Rust Language.<br/> <br/> [English README is here](https://github.com/BonoJovi/KakeiBonByRust/blob/dev/README_en.md)<br/> <br/> 家計簿アプリ「KakeiBon」Rust版<br/> [日本語版READMEはこちら](https://github.com/BonoJovi/KakeiBonByRust/blob/dev/README_ja.md)<br/>",
   "main": "index.js",
   "directories": {

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -8,7 +8,6 @@ pub const ROLE_VISIT: i64 = 999;
 // Database constants
 pub const DB_DIR_NAME: &str = ".kakeibon";
 pub const DB_FILE_NAME: &str = "KakeiBonDB.sqlite3";
-pub const SQL_INIT_FILE_PATH: &str = "res/sql/dbaccess.sql";
 
 // Language constants
 pub const LANG_ENGLISH: &str = "en";

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,13 @@
 use sqlx::sqlite::SqlitePool;
 use std::path::PathBuf;
-use crate::consts::{DB_DIR_NAME, DB_FILE_NAME, SQL_INIT_FILE_PATH};
+use crate::consts::{DB_DIR_NAME, DB_FILE_NAME};
 use crate::sql_queries;
+
+// Schema is embedded at compile time. Reading via std::fs::read_to_string with a
+// CWD-relative path silently works under `cargo tauri dev` (CWD = project root)
+// but crashes the installed .msi/.exe at startup, because the installed app's
+// CWD is the install directory and `res/sql/dbaccess.sql` is not there.
+const INIT_SQL: &str = include_str!("../res/sql/dbaccess.sql");
 
 /// Connect to a SQLite database with the given URL
 pub async fn connect_db(db_url: &str) -> Result<SqlitePool, sqlx::Error> {
@@ -53,15 +59,8 @@ impl Database {
     }
     
     pub async fn initialize(&self) -> Result<(), sqlx::Error> {
-        // Load SQL from file
-        let sql_path = get_sql_file_path();
-        let sql_content = std::fs::read_to_string(&sql_path)
-            .map_err(|e| sqlx::Error::Configuration(
-                format!("Failed to read SQL file at {}: {}", sql_path.display(), e).into()
-            ))?;
-        
         // Remove comment lines first
-        let cleaned_sql: Vec<&str> = sql_content
+        let cleaned_sql: Vec<&str> = INIT_SQL
             .lines()
             .filter(|line| !line.trim().starts_with("--") && !line.trim().is_empty())
             .collect();
@@ -468,14 +467,10 @@ pub fn get_db_path() -> PathBuf {
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .unwrap_or_else(|_| ".".to_string());
-    
+
     PathBuf::from(home)
         .join(DB_DIR_NAME)
         .join(DB_FILE_NAME)
-}
-
-fn get_sql_file_path() -> PathBuf {
-    PathBuf::from(SQL_INIT_FILE_PATH)
 }
 
 #[cfg(test)]

--- a/src/services/category.rs
+++ b/src/services/category.rs
@@ -64,12 +64,14 @@ impl CategoryService {
             return Ok(());
         }
         
-        // Read SQL file BEFORE starting transaction to avoid long-running transaction
-        let sql_content = std::fs::read_to_string("res/sql/default_categories_seed.sql")
-            .map_err(|e| CategoryError::DatabaseError(sqlx::Error::Io(e)))?;
-        
+        // Seed SQL is embedded at compile time. Reading from a CWD-relative
+        // path silently works under `cargo tauri dev` (CWD = project root) but
+        // crashes installed .msi/.exe builds because the install directory is
+        // the CWD and `res/sql/default_categories_seed.sql` isn't shipped there.
+        const DEFAULT_CATEGORIES_SEED: &str = include_str!("../../res/sql/default_categories_seed.sql");
+
         // Replace :pUserID placeholder with actual user_id
-        let sql_content = sql_content.replace(":pUserID", &user_id.to_string());
+        let sql_content = DEFAULT_CATEGORIES_SEED.replace(":pUserID", &user_id.to_string());
         
         // Start transaction
         let mut tx = self.pool.begin().await?;

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "KakeiBon",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "identifier": "org.zundou.kakeibon",
   "build": {
     "frontendDist": "./res",


### PR DESCRIPTION
## Summary

- Fixes #62 — Windows distribution `.msi`/`.exe` startup crash.
- Switches `Database::initialize()` and `CategoryService::populate_default_categories()` from CWD-relative `std::fs::read_to_string` to compile-time `include_str!`.
- Drops the now-unused `SQL_INIT_FILE_PATH` constant and `get_sql_file_path()` helper.
- Version bump to v2.4.1.

## Root cause

The installed Windows bundle's CWD is the install directory, where `res/sql/dbaccess.sql` and `res/sql/default_categories_seed.sql` are not shipped. `cargo tauri dev` masked this because its CWD is the project root. `.expect("Failed to initialize database")` in `setup()` panicked the process before the window finished opening — meaning **v2.0.0 onward Windows distribution builds have never actually launched for end users**.

## Test plan

- [x] `cargo test` — 390 backend tests pass
- [x] `./scripts/check-release.sh` — all release-mode checks green
- [ ] Post-release: install `KakeiBon_2.4.1_x64-setup.exe` on a clean Windows VM and verify the login screen opens
- [ ] Post-release: register a new user and confirm default categories seed succeeds

## Out of scope

- `lib.rs:2532-2550` `.expect()` 6 連発 (CLAUDE.md "No unwrap() in production Rust" violation) — not addressed in this hotfix because `include_str!` removes the panic path. Separate issue to follow.
- v2.5.0 Windows window-position bug (#60) — resumes after v2.4.1 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)